### PR TITLE
Net: fix crash on HTTP connection to ACME server.

### DIFF
--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -148,7 +148,7 @@ impl HttpClient for NgxHttpClient<'_> {
             .connect_to(authority.as_str(), &self.resolver, ssl)
             .await?;
 
-        if self.ssl_verify {
+        if ssl.is_some() && self.ssl_verify {
             if let Err(err) = peer.verify_peer() {
                 let _ = future::poll_fn(|cx| peer.as_mut().poll_shutdown(cx)).await;
                 return Err(err.into());

--- a/src/net/peer_conn.rs
+++ b/src/net/peer_conn.rs
@@ -219,6 +219,13 @@ impl PeerConnection {
     pub fn verify_peer(&mut self) -> Result<(), io::Error> {
         let c = self.connection_mut().ok_or(io::ErrorKind::NotConnected)?;
 
+        if c.ssl.is_null() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "cannot verify peer on a non-SSL connection",
+            ));
+        }
+
         let rc = unsafe { SSL_get_verify_result((*c.ssl).connection.cast()) };
         if rc != (X509_V_OK as c_long) {
             let err = unsafe { CStr::from_ptr(X509_verify_cert_error_string(rc)) };


### PR DESCRIPTION
Plain HTTP connections are prohibited by the ACME specification, so we did not have this scenario in our test automation and overlooked the regression during the pre-release code cleanup. Nonetheless, some server implementations allow such configuration and more importantly the HTTP client code should be useful as an example for other modules.