### PR TITLE
ACME: mark unused directory resources as optional.

### DIFF
--- a/src/acme/types.rs
+++ b/src/acme/types.rs
@@ -36,10 +36,10 @@ pub struct Directory {
     pub new_order: Uri,
     #[serde(default, with = "http_serde::option::uri")]
     pub new_authz: Option<Uri>,
-    #[serde(with = "http_serde::uri")]
-    pub revoke_cert: Uri,
-    #[serde(with = "http_serde::uri")]
-    pub key_change: Uri,
+    #[serde(default, with = "http_serde::option::uri")]
+    pub revoke_cert: Option<Uri>,
+    #[serde(default, with = "http_serde::option::uri")]
+    pub key_change: Option<Uri>,
     #[serde(default)]
     pub meta: DirectoryMetadata,
 }


### PR DESCRIPTION
We discovered a server implementation that does not support key rollover and indicates that by not sending "keyChange".
For completeness, I'm marking all the currently unused directory resources as optional.