### PR TITLE
Docs: clarify build requirements and SSL library support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ server {
 
 ## Directives
 
+> [!IMPORTANT]
+> The reference below reflects the current development version. See
+> [ngx_http_acme_module](https://nginx.org/en/docs/http/ngx_http_acme_module.html)
+> documentation on [nginx.org](https://nginx.org) for the latest released version.
+
 ### acme_issuer
 
 **Syntax:** acme_issuer `name` { ... }


### PR DESCRIPTION
Not sure if the N+ compatibility note is acceptable here, but it seems necessary after the previous paragraph.

Fixes #36
Fixes #53 by explicitly stating that mismatched SSL libraries are unsupported and pointing to the compatibility table.