### PR TITLE
Apply state prefix to a relative "state_path".

### DIFF
--- a/src/conf/ext.rs
+++ b/src/conf/ext.rs
@@ -13,6 +13,7 @@ use ngx::ngx_conf_log_error;
 
 pub trait NgxConfExt {
     fn args(&self) -> &[ngx_str_t];
+    fn args_mut(&mut self) -> &mut [ngx_str_t];
     fn error(&self, dir: impl AsRef<[u8]>, err: &dyn StdError) -> *mut c_char;
     fn pool(&self) -> ngx::core::Pool;
 }
@@ -21,6 +22,16 @@ impl NgxConfExt for ngx_conf_t {
     fn args(&self) -> &[ngx_str_t] {
         // SAFETY: we know that cf.args is an array of ngx_str_t
         unsafe { self.args.as_ref().map(|x| x.as_slice()).unwrap_or_default() }
+    }
+
+    fn args_mut(&mut self) -> &mut [ngx_str_t] {
+        // SAFETY: we know that cf.args is an array of ngx_str_t
+        unsafe {
+            self.args
+                .as_mut()
+                .map(|x| x.as_slice_mut())
+                .unwrap_or_default()
+        }
     }
 
     fn error(&self, dir: impl AsRef<[u8]>, err: &dyn StdError) -> *mut c_char {


### PR DESCRIPTION
Previously, we would prepend NGX_ACME_STATE_PREFIX to default paths and cycle->prefix to explicitly configured paths.  This seems inconsistent and unnecesarily confusing.

Fixes 131a681.