### PR TITLE
Fix: change caa_identities field to be optional in DirectoryMetadata

### DIFF
--- a/src/acme/types.rs
+++ b/src/acme/types.rs
@@ -20,7 +20,7 @@ pub struct DirectoryMetadata {
     pub terms_of_service: Option<String>,
     #[serde(with = "http_serde::option::uri")]
     pub website: Option<Uri>,
-    pub caa_identities: Vec<String>,
+    pub caa_identities: Option<Vec<String>>,
     pub external_account_required: Option<bool>,
 }
 


### PR DESCRIPTION
Fix for https://github.com/nginx/nginx-acme/issues/73