### PR TITLE
Fix: ACME directory URL redirects are not followed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "iri-string"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +351,7 @@ dependencies = [
  "http-body-util",
  "http-serde",
  "hyper",
+ "iri-string",
  "libc",
  "nginx-sys",
  "ngx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ http-body = "1.0.1"
 http-body-util = "0.1.3"
 http-serde = "2.1.1"
 hyper = { version = "1.6.0", features = ["client", "http1"] }
+iri-string = "0.7.9"
 libc = "0.2.174"
 nginx-sys = "0.5.0"
 ngx = { version = "0.5.0", features = ["async", "serde", "std"] }

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -10,8 +10,9 @@ use std::collections::VecDeque;
 use std::string::{String, ToString};
 
 use bytes::Bytes;
-use error::{NewAccountError, NewCertificateError, RequestError};
+use error::{NewAccountError, NewCertificateError, RedirectError, RequestError};
 use http::Uri;
+use iri_string::types::{UriAbsoluteString, UriReferenceStr};
 use ngx::allocator::{Allocator, Box};
 use ngx::async_::sleep;
 use ngx::collections::Vec;
@@ -42,6 +43,9 @@ const MAX_BACKOFF_INTERVAL: Duration = Duration::from_secs(8);
 const MAX_SERVER_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 
 static REPLAY_NONCE: http::HeaderName = http::HeaderName::from_static("replay-nonce");
+
+// Maximum number of redirects to follow for a single request.
+const MAX_REDIRECTS: usize = 10;
 
 pub enum NewAccountOutput<'a> {
     Created(&'a str),
@@ -107,6 +111,13 @@ fn try_get_header<K: http::header::AsHeaderName>(
     headers.get(key).and_then(|x| x.to_str().ok())
 }
 
+fn resolve_uri(base: &Uri, relative: &str) -> Option<Uri> {
+    let base_abs = UriAbsoluteString::try_from(base.to_string()).ok()?;
+    let location_ref = UriReferenceStr::new(relative).ok()?;
+    let resolved = location_ref.resolve_against(&base_abs).to_string();
+    Uri::try_from(resolved).ok()
+}
+
 impl<'a, Http> AcmeClient<'a, Http>
 where
     Http: HttpClient,
@@ -170,12 +181,27 @@ where
     }
 
     pub async fn get(&self, url: &Uri) -> Result<http::Response<Bytes>, RequestError> {
-        let req = http::Request::builder()
-            .uri(url)
-            .method(http::Method::GET)
-            .header(http::header::CONTENT_LENGTH, 0)
-            .body(String::new())?;
-        Ok(self.http.request(req).await?)
+        let mut u = url.clone();
+
+        for _ in 0..MAX_REDIRECTS {
+            let req = http::Request::builder()
+                .uri(&u)
+                .method(http::Method::GET)
+                .header(http::header::CONTENT_LENGTH, 0)
+                .body(String::new())?;
+            let res = self.http.request(req).await?;
+
+            if res.status().is_redirection() {
+                let location = try_get_header(res.headers(), http::header::LOCATION)
+                    .ok_or(RedirectError::MissingRedirectUri)?;
+                u = resolve_uri(&u, location).ok_or(RedirectError::InvalidRedirectUri)?;
+                continue;
+            }
+
+            return Ok(res);
+        }
+
+        Err(RedirectError::TooManyRedirects.into())
     }
 
     pub async fn post<P: AsRef<[u8]>>(

--- a/src/acme/error.rs
+++ b/src/acme/error.rs
@@ -115,6 +115,18 @@ impl NewCertificateError {
 }
 
 #[derive(Debug, Error)]
+pub enum RedirectError {
+    #[error("invalid redirect URI")]
+    InvalidRedirectUri,
+
+    #[error("missing redirect URI")]
+    MissingRedirectUri,
+
+    #[error("too many redirects")]
+    TooManyRedirects,
+}
+
+#[derive(Debug, Error)]
 pub enum RequestError {
     #[error(transparent)]
     Client(Box<dyn StdError + Send + Sync>),
@@ -136,6 +148,9 @@ pub enum RequestError {
 
     #[error("rate limit exceeded, next attempt in {0:?}")]
     RateLimited(Duration),
+
+    #[error("redirect failed: {0}")]
+    Redirect(#[from] RedirectError),
 
     #[error("cannot serialize request ({0})")]
     RequestFormat(serde_json::Error),


### PR DESCRIPTION
Partial fix for https://github.com/nginx/nginx-acme/issues/75

Technically this PR fixes the general redirect aspects for the GET call in `acme.rs`.
As of now the POST from `acme.rs` would still not be covered:
https://github.com/nginx/nginx-acme/blob/main/src/acme.rs#L181

Based on my testing this should only affect use-cases where URLs (relative, or absolute) are returned, that cause another redirect, which should be rarely the case (at least not in the environments I tested with). Reason being, that the URLs provided by `https://acme.example.com/directory` should normally be OK not requiring redirects.

Also I'm not completely sure how to best implement the requirements for `RFC 8555 §6.2`.
I can add those as well if needed, though it might be best to extract part of the redirect functionality to it's own (reusable) unit I assume.
Any opinions on this matter?

IMO this basic PR should already cover a few additional standard use cases, such as:
- HTTP -> HTTPS
- `https://acme.example.com/directory` -> `https://acme.example.com/some-id/directory` (from https://github.com/nginx/nginx-acme/issues/75)