### PR TITLE
CI: run unittests with MSRV toolchain.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,3 +161,11 @@ jobs:
         # always run if build succeeds
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: make BUILD=${{ matrix.build }} TEST_PREREQ= ${{ env.testTarget }}
+
+      - name: run unittests
+        # unittests cannot link with Rust >= 1.89, so we limit execution to MSRV
+        if: >-
+          ${{ !cancelled() && steps.build.outcome == 'success' &&
+              matrix.rust-version == needs.rust-version.outputs.version
+          }}
+        run: make BUILD=${{ matrix.build }} unittest


### PR DESCRIPTION
See 1141c24b505c3b09cbe074caec27912bc62796f3 for details.
I don't have the solution for linking issues yet, but we still can run the tests with the oldest supported compiler.