### PR TITLE
Conf: ensure minimal required shared zone size.

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -21,7 +21,7 @@ use self::ext::NgxConfExt;
 use self::issuer::Issuer;
 use self::order::CertificateOrder;
 use self::pkey::PrivateKey;
-use self::shared_zone::{SharedZone, ACME_ZONE_NAME, ACME_ZONE_SIZE};
+use self::shared_zone::{acme_zone_min_size, SharedZone, ACME_ZONE_NAME, ACME_ZONE_SIZE};
 use self::ssl::NgxSsl;
 use crate::acme::types::ChallengeKind;
 use crate::state::AcmeSharedData;
@@ -761,7 +761,8 @@ impl AcmeMainConfig {
         /* Request shared zone allocation */
 
         if !self.shm_zone.is_configured() {
-            self.shm_zone = SharedZone::Configured(ACME_ZONE_NAME, ACME_ZONE_SIZE);
+            let size = core::cmp::max(ACME_ZONE_SIZE, acme_zone_min_size());
+            self.shm_zone = SharedZone::Configured(ACME_ZONE_NAME, size);
         }
 
         let amcfp = ptr::from_mut(self).cast();

--- a/src/conf/shared_zone.rs
+++ b/src/conf/shared_zone.rs
@@ -16,6 +16,10 @@ use thiserror::Error;
 pub const ACME_ZONE_NAME: ngx_str_t = ngx_string!("ngx_acme_shared");
 pub const ACME_ZONE_SIZE: usize = 1 << 18;
 
+pub fn acme_zone_min_size() -> usize {
+    unsafe { nginx_sys::ngx_pagesize * 8 }
+}
+
 #[derive(Clone, Debug, Default)]
 #[allow(unused)]
 pub enum SharedZone {
@@ -75,7 +79,7 @@ impl SharedZone {
             return Err(SharedZoneError::AlreadyConfigured);
         }
 
-        if size < unsafe { nginx_sys::ngx_pagesize * 8 } {
+        if size < acme_zone_min_size() {
             return Err(SharedZoneError::TooSmall(name));
         }
 


### PR DESCRIPTION
The default value we have is insufficient for larger page sizes, for example when running on aarch64 or ppc64 with 64k pages.