### PR TITLE
Tests: set server names hash bucket size to 64.

### DIFF
--- a/t/acme_external_account.t
+++ b/t/acme_external_account.t
@@ -43,6 +43,8 @@ http {
 
     resolver 127.0.0.1:%%PORT_8980_UDP%%;
 
+    server_names_hash_bucket_size 64;
+
     acme_issuer eab-data {
         uri https://acme.test:%%PORT_9000%%/dir;
         external_account_key eab-data

--- a/t/acme_key_type.t
+++ b/t/acme_key_type.t
@@ -43,6 +43,8 @@ http {
 
     resolver 127.0.0.1:%%PORT_8980_UDP%%;
 
+    server_names_hash_bucket_size 64;
+
     acme_issuer default {
         uri https://acme.test:%%PORT_9000%%/dir;
         ssl_trusted_certificate acme.test.crt;


### PR DESCRIPTION
server_names_hash_bucket_size defaults to the detected processor's cache line size.  Some of our tests fail when the names used don't fit into 32 bytes buckets, and require specifying bucket size explicitly.