### PR TITLE
Tests: set server names hash bucket size for acme_ssl_verify.t.

### DIFF
--- a/t/acme_ssl_verify.t
+++ b/t/acme_ssl_verify.t
@@ -46,6 +46,8 @@ http {
 
     resolver 127.0.0.1:%%PORT_8980_UDP%%;
 
+    server_names_hash_bucket_size 64;
+
     acme_issuer verify-off {
         uri https://bad.acme.test:%%PORT_9000%%/dir;
         ssl_verify off;


### PR DESCRIPTION
Our favorite 32-bit 64-bit system strikes again.

More context in #111.