### PR TITLE
Split acme::types into request and resource types.

### DIFF
--- a/src/acme/error.rs
+++ b/src/acme/error.rs
@@ -9,8 +9,8 @@ use core::time::Duration;
 use ngx::allocator::{unsize_box, Box};
 use thiserror::Error;
 
+use super::resource::{AccountStatus, Problem, ProblemCategory};
 use super::solvers::SolverError;
-use super::types::{AccountStatus, Problem, ProblemCategory};
 use crate::net::http::HttpClientError;
 
 #[derive(Debug, Error)]
@@ -60,10 +60,10 @@ impl NewAccountError {
 #[derive(Debug, Error)]
 pub enum NewCertificateError {
     #[error("unexpected authorization status {0:?}")]
-    AuthorizationStatus(super::types::AuthorizationStatus),
+    AuthorizationStatus(super::resource::AuthorizationStatus),
 
     #[error("unexpected challenge status {0:?}")]
-    ChallengeStatus(super::types::ChallengeStatus),
+    ChallengeStatus(super::resource::ChallengeStatus),
 
     #[error("csr generation failed ({0})")]
     Csr(openssl::error::ErrorStack),
@@ -78,7 +78,7 @@ pub enum NewCertificateError {
     NoSupportedChallenges,
 
     #[error("unexpected order status {0:?}")]
-    OrderStatus(super::types::OrderStatus),
+    OrderStatus(super::resource::OrderStatus),
 
     #[error("invalid or missing order URL")]
     OrderUrl,

--- a/src/acme/request.rs
+++ b/src/acme/request.rs
@@ -1,0 +1,37 @@
+// Copyright (c) F5, Inc.
+//
+// This source code is licensed under the Apache License, Version 2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+
+use std::string::String;
+
+use serde::Serialize;
+
+use crate::conf::identifier::Identifier;
+
+/// RFC8555 Section 7.3 Account Management
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Account<'a> {
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    pub contact: &'a [&'a str],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terms_of_service_agreed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub only_return_existing: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_account_binding: Option<crate::jws::SignedMessage>,
+}
+
+/// RFC8555 Section 7.4 Applying for Certificate Issuance
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Order<'a> {
+    pub identifiers: &'a [Identifier<&'a str>],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub not_before: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub not_after: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<&'a str>,
+}

--- a/src/acme/resource.rs
+++ b/src/acme/resource.rs
@@ -10,7 +10,7 @@ use std::string::{String, ToString};
 
 use http::Uri;
 use ngx::collections::Vec;
-use serde::{de::IgnoredAny, Deserialize, Serialize};
+use serde::{de::IgnoredAny, Deserialize};
 
 use crate::conf::identifier::Identifier;
 
@@ -65,20 +65,6 @@ pub struct Account {
     pub terms_of_service_agreed: bool,
 }
 
-/// RFC8555 Section 7.3 Account Management
-#[derive(Debug, Default, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AccountRequest<'a> {
-    #[serde(skip_serializing_if = "<[_]>::is_empty")]
-    pub contact: &'a [&'a str],
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub terms_of_service_agreed: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub only_return_existing: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub external_account_binding: Option<crate::jws::SignedMessage>,
-}
-
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderStatus {
@@ -109,19 +95,6 @@ pub struct Order<'a> {
     pub finalize: Uri,
     #[serde(default, with = "http_serde::option::uri")]
     pub certificate: Option<Uri>,
-}
-
-/// RFC8555 Section 7.4 Applying for Certificate Issuance
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderRequest<'a> {
-    pub identifiers: &'a [Identifier<&'a str>],
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub not_before: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub not_after: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub profile: Option<&'a str>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]

--- a/src/acme/solvers.rs
+++ b/src/acme/solvers.rs
@@ -5,7 +5,7 @@
 
 use thiserror::Error;
 
-use super::types::{Challenge, ChallengeKind};
+use super::resource::{Challenge, ChallengeKind};
 use super::AuthorizationContext;
 use crate::conf::identifier::Identifier;
 

--- a/src/acme/solvers/http.rs
+++ b/src/acme/solvers/http.rs
@@ -19,6 +19,7 @@ use ngx::{http_request_handler, ngx_log_debug_http};
 
 use super::{ChallengeSolver, SolverError};
 use crate::acme;
+use crate::acme::resource::{Challenge, ChallengeKind};
 use crate::conf::identifier::Identifier;
 use crate::conf::AcmeMainConfig;
 
@@ -54,15 +55,15 @@ impl<'a> Http01Solver<'a> {
 }
 
 impl ChallengeSolver for Http01Solver<'_> {
-    fn supports(&self, c: &acme::types::ChallengeKind) -> bool {
-        matches!(c, crate::acme::types::ChallengeKind::Http01)
+    fn supports(&self, c: &ChallengeKind) -> bool {
+        matches!(c, ChallengeKind::Http01)
     }
 
     fn register(
         &self,
         ctx: &acme::AuthorizationContext,
         _identifier: &Identifier<&str>,
-        challenge: &acme::types::Challenge,
+        challenge: &Challenge,
     ) -> Result<(), SolverError> {
         let alloc = self.0.read().allocator().clone();
 
@@ -80,7 +81,7 @@ impl ChallengeSolver for Http01Solver<'_> {
     fn unregister(
         &self,
         _identifier: &Identifier<&str>,
-        challenge: &acme::types::Challenge,
+        challenge: &Challenge,
     ) -> Result<(), SolverError> {
         self.0.write().remove(challenge.token.as_bytes());
         Ok(())

--- a/src/acme/solvers/tls_alpn.rs
+++ b/src/acme/solvers/tls_alpn.rs
@@ -44,7 +44,7 @@ use openssl_sys::{SSL_get_ex_data, SSL, SSL_CTX, SSL_TLSEXT_ERR_ALERT_FATAL, SSL
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::acme;
-use crate::acme::types::ChallengeKind;
+use crate::acme::resource::{Challenge, ChallengeKind};
 use crate::conf::identifier::Identifier;
 use crate::conf::AcmeMainConfig;
 
@@ -136,7 +136,7 @@ impl ChallengeSolver for TlsAlpn01Solver<'_> {
         &self,
         ctx: &acme::AuthorizationContext,
         identifier: &Identifier<&str>,
-        challenge: &acme::types::Challenge,
+        challenge: &Challenge,
     ) -> Result<(), SolverError> {
         let alloc = self.0.read().allocator().clone();
 
@@ -160,7 +160,7 @@ impl ChallengeSolver for TlsAlpn01Solver<'_> {
     fn unregister(
         &self,
         identifier: &Identifier<&str>,
-        _challenge: &acme::types::Challenge,
+        _challenge: &Challenge,
     ) -> Result<(), SolverError> {
         self.0.write().remove(identifier.value().as_bytes());
         Ok(())

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -23,7 +23,7 @@ use self::order::CertificateOrder;
 use self::pkey::PrivateKey;
 use self::shared_zone::{acme_zone_min_size, SharedZone, ACME_ZONE_NAME, ACME_ZONE_SIZE};
 use self::ssl::NgxSsl;
-use crate::acme::types::ChallengeKind;
+use crate::acme::ChallengeKind;
 use crate::state::AcmeSharedData;
 
 pub mod ext;

--- a/src/conf/issuer.rs
+++ b/src/conf/issuer.rs
@@ -28,7 +28,7 @@ use super::order::CertificateOrder;
 use super::pkey::PrivateKey;
 use super::ssl::NgxSsl;
 use super::AcmeMainConfig;
-use crate::acme::types::ChallengeKind;
+use crate::acme::ChallengeKind;
 use crate::state::certificate::{CertificateContext, CertificateContextInner};
 use crate::state::issuer::{IssuerContext, IssuerState};
 use crate::time::{Time, TimeRange};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,11 +242,11 @@ async fn ngx_http_acme_update_certificates_for_issuer(
     let amsh = amcf.data.expect("acme shared data");
 
     match issuer.challenge {
-        Some(acme::types::ChallengeKind::Http01) => {
+        Some(acme::ChallengeKind::Http01) => {
             let http_solver = acme::solvers::http::Http01Solver::new(&amsh.http_01_state);
             client.add_solver(http_solver);
         }
-        Some(acme::types::ChallengeKind::TlsAlpn01) => {
+        Some(acme::ChallengeKind::TlsAlpn01) => {
             let tls_solver = acme::solvers::tls_alpn::TlsAlpn01Solver::new(&amsh.tls_alpn_01_state);
             client.add_solver(tls_solver);
         }


### PR DESCRIPTION
Just a small refactoring that could be separated from the current ARI work.