### PR TITLE
Reformat with use_small_heuristics = "Max".

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -76,10 +76,7 @@ fn detect_libssl_features() {
     let openssl_version = env::var("DEP_OPENSSL_VERSION_NUMBER").unwrap_or_default();
     let openssl_version = u64::from_str_radix(&openssl_version, 16).unwrap_or(0);
 
-    println!(
-        "cargo::rustc-check-cfg=cfg(openssl, values(\"{}\"))",
-        openssl_features.join("\",\"")
-    );
+    println!("cargo::rustc-check-cfg=cfg(openssl, values(\"{}\"))", openssl_features.join("\",\""));
 
     #[allow(clippy::unusual_byte_groupings)]
     let openssl = if env::var("DEP_OPENSSL_AWSLC").is_ok() {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,6 @@
 edition = "2021"
 max_width = 100
+use_small_heuristics = "Max"
 
 # unstable options:
 # comment_width = 100

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -134,11 +134,7 @@ where
         log: NonNull<nginx_sys::ngx_log_t>,
     ) -> Result<Self, AccountKeyError> {
         let key = AccountKey::try_from(
-            issuer
-                .pkey
-                .as_ref()
-                .expect("checked during configuration load")
-                .as_ref(),
+            issuer.pkey.as_ref().expect("checked during configuration load").as_ref(),
         )?;
 
         Ok(Self {
@@ -181,9 +177,7 @@ where
 
     async fn get_nonce(&self) -> Result<String, RequestError> {
         let res = self.get(&self.directory.new_nonce).await?;
-        try_get_header(res.headers(), &REPLAY_NONCE)
-            .ok_or(RequestError::Nonce)
-            .map(String::from)
+        try_get_header(res.headers(), &REPLAY_NONCE).ok_or(RequestError::Nonce).map(String::from)
     }
 
     pub async fn get(&self, url: &Uri) -> Result<http::Response<Bytes>, RequestError> {
@@ -215,11 +209,8 @@ where
         url: &Uri,
         payload: P,
     ) -> Result<http::Response<Bytes>, RequestError> {
-        let mut nonce = if let Some(nonce) = self.nonce.get() {
-            nonce
-        } else {
-            self.get_nonce().await?
-        };
+        let mut nonce =
+            if let Some(nonce) = self.nonce.get() { nonce } else { self.get_nonce().await? };
 
         let mut tries = core::iter::repeat(DEFAULT_RETRY_INTERVAL).take(self.network_error_retries);
 
@@ -302,10 +293,7 @@ where
     }
 
     pub async fn new_account(&mut self) -> Result<NewAccountOutput<'_>, NewAccountError> {
-        self.directory = self
-            .get_directory()
-            .await
-            .map_err(NewAccountError::Directory)?;
+        self.directory = self.get_directory().await.map_err(NewAccountError::Directory)?;
 
         if self.directory.meta.external_account_required == Some(true)
             && self.issuer.eab_key.is_none()
@@ -384,11 +372,7 @@ where
     where
         A: Allocator,
     {
-        ngx_log_debug!(
-            self.log.as_ptr(),
-            "new certificate request: {:?}",
-            req.identifiers
-        );
+        ngx_log_debug!(self.log.as_ptr(), "new certificate request: {:?}", req.identifiers);
         let identifiers: Vec<Identifier<&str>> =
             req.identifiers.iter().map(|x| x.as_ref()).collect();
 
@@ -416,9 +400,7 @@ where
 
             match authorization.status {
                 resource::AuthorizationStatus::Pending => {
-                    authorization
-                        .challenges
-                        .retain(|x| self.is_supported_challenge(&x.kind));
+                    authorization.challenges.retain(|x| self.is_supported_challenge(&x.kind));
 
                     if authorization.challenges.is_empty() {
                         return Err(NewCertificateError::NoSupportedChallenges);
@@ -440,10 +422,7 @@ where
 
         let pkey = req.key.generate()?;
 
-        let order = AuthorizationContext {
-            thumbprint: self.key.thumbprint(),
-            pkey: &pkey,
-        };
+        let order = AuthorizationContext { thumbprint: self.key.thumbprint(), pkey: &pkey };
 
         for (url, authorization) in pending_authorizations {
             self.do_authorization(&order, url, authorization).await?;
@@ -489,16 +468,12 @@ where
             order = deserialize_body(res.body())?;
         }
 
-        let certificate = order
-            .certificate
-            .ok_or(NewCertificateError::MissingCertificate)?;
+        let certificate = order.certificate.ok_or(NewCertificateError::MissingCertificate)?;
 
         let res = self.post(&certificate, b"").await?;
 
         if let Some(ref matcher) = self.issuer.chain {
-            let (bytes, x509) = self
-                .find_preferred_chain(&certificate, res, matcher)
-                .await?;
+            let (bytes, x509) = self.find_preferred_chain(&certificate, res, matcher).await?;
             Ok(NewCertificateOutput { bytes, x509, pkey })
         } else {
             let bytes = res.into_body();

--- a/src/acme/error.rs
+++ b/src/acme/error.rs
@@ -47,10 +47,9 @@ impl NewAccountError {
     pub fn is_invalid(&self) -> bool {
         match self {
             Self::ExternalAccount => true,
-            Self::Protocol(err) => matches!(
-                err.category(),
-                ProblemCategory::Account | ProblemCategory::Malformed
-            ),
+            Self::Protocol(err) => {
+                matches!(err.category(), ProblemCategory::Account | ProblemCategory::Malformed)
+            }
             Self::Status(_) => true,
             _ => false,
         }
@@ -108,10 +107,9 @@ impl From<RequestError> for NewCertificateError {
 impl NewCertificateError {
     pub fn is_invalid(&self) -> bool {
         match self {
-            Self::Protocol(err) => matches!(
-                err.category(),
-                ProblemCategory::Order | ProblemCategory::Malformed
-            ),
+            Self::Protocol(err) => {
+                matches!(err.category(), ProblemCategory::Order | ProblemCategory::Malformed)
+            }
             _ => false,
         }
     }

--- a/src/acme/headers.rs
+++ b/src/acme/headers.rs
@@ -72,11 +72,11 @@ impl<'a> Iterator for LinkIter<'a> {
                 let value;
                 (name, value, p) = consume_link_param(p)?;
 
-                // 9.   Let relations_string be the second item of the first tuple
-                //      of link_parameters whose first item matches the string "rel"
-                //      or the empty string ("") if it is not present.
-                // 10.  Split relations_string on RWS (removing it in the process)
-                //      into a list of string relation_types.
+                // 9. Let relations_string be the second item of the first tuple of link_parameters
+                //    whose first item matches the string "rel" or the empty string ("") if it is
+                //    not present.
+                // 10. Split relations_string on RWS (removing it in the process) into a list of
+                //     string relation_types.
 
                 if rel.is_empty() && name.eq_ignore_ascii_case("rel") {
                     rel.extend(value.split_ascii_whitespace());
@@ -176,18 +176,12 @@ mod tests {
             (
                 // alternate quoted
                 "<https://example.com/acme/cert/mAt3xBGaobw/1>; rel=\"alternate\"",
-                &[(
-                    "https://example.com/acme/cert/mAt3xBGaobw/1",
-                    &["alternate"],
-                )],
+                &[("https://example.com/acme/cert/mAt3xBGaobw/1", &["alternate"])],
             ),
             (
                 // alternate unquoted
                 "<https://example.com/acme/cert/mAt3xBGaobw/1>; rel=alternate",
-                &[(
-                    "https://example.com/acme/cert/mAt3xBGaobw/1",
-                    &["alternate"],
-                )],
+                &[("https://example.com/acme/cert/mAt3xBGaobw/1", &["alternate"])],
             ),
             (
                 // no rel
@@ -207,12 +201,14 @@ mod tests {
             (
                 // spaces, commas and other parser sanity checks
                 concat!(
-                    " , <https://example.com/acme/directory> ;\t foo=\";,=<>\"; rel = \"index\"\t,  ,,, ",
-                    " , <https://example.com/acme/directory> ;\t foo=\";,=<>\"; rel = \"index\"\t,  ,,, "
+                    " , <https://example.com/acme/directory> ;\t foo=\";,=<>\"; rel = \
+                     \"index\"\t,  ,,, ",
+                    " , <https://example.com/acme/directory> ;\t foo=\";,=<>\"; rel = \
+                     \"index\"\t,  ,,, "
                 ),
                 &[
                     ("https://example.com/acme/directory", &["index"]),
-                    ("https://example.com/acme/directory", &["index"])
+                    ("https://example.com/acme/directory", &["index"]),
                 ],
             ),
             (
@@ -232,14 +228,8 @@ mod tests {
                 ),
                 &[
                     ("https://example.com/acme/directory", &["index"]),
-                    (
-                        "https://example.com/acme/cert/mAt3xBGaobw/1",
-                        &["alternate"],
-                    ),
-                    (
-                        "https://example.com/acme/cert/mAt3xBGaobw/2",
-                        &["alternate"],
-                    ),
+                    ("https://example.com/acme/cert/mAt3xBGaobw/1", &["alternate"]),
+                    ("https://example.com/acme/cert/mAt3xBGaobw/2", &["alternate"]),
                 ],
             ),
             (
@@ -250,10 +240,7 @@ mod tests {
                     "</TheBook/chapter4>;",
                     "title*=UTF-8'de'n%c3%a4chstes%20Kapitel; rel=\"next\"",
                 ),
-                &[
-                    ("/TheBook/chapter2", &["previous"]),
-                    ("/TheBook/chapter4", &["next"]),
-                ],
+                &[("/TheBook/chapter2", &["previous"]), ("/TheBook/chapter4", &["next"])],
             ),
             // bad values
             ("<asdf", &[]),

--- a/src/acme/resource.rs
+++ b/src/acme/resource.rs
@@ -206,10 +206,7 @@ const ERROR_KIND: &[(&str, ErrorKind)] = &[
     ("compound", ErrorKind::Compound),
     ("connection", ErrorKind::Connection),
     ("dns", ErrorKind::Dns),
-    (
-        "externalAccountRequired",
-        ErrorKind::ExternalAccountRequired,
-    ),
+    ("externalAccountRequired", ErrorKind::ExternalAccountRequired),
     ("incorrectResponse", ErrorKind::IncorrectResponse),
     ("invalidContact", ErrorKind::InvalidContact),
     ("invalidProfile", ErrorKind::InvalidProfile),
@@ -569,9 +566,6 @@ mod tests {
 
         assert_eq!(err.kind, ErrorKind::Malformed);
         assert_eq!(err.subproblems.len(), 2);
-        assert_eq!(
-            err.subproblems[0].identifier,
-            Some(Identifier::Dns("_example.org".to_string()))
-        )
+        assert_eq!(err.subproblems[0].identifier, Some(Identifier::Dns("_example.org".to_string())))
     }
 }

--- a/src/acme/solvers/http.rs
+++ b/src/acme/solvers/http.rs
@@ -98,11 +98,7 @@ http_request_handler!(handler, |r: &mut ngx::http::Request| {
         return Status::NGX_DECLINED;
     };
 
-    let Some(token) = r
-        .path()
-        .as_bytes()
-        .strip_prefix(b"/.well-known/acme-challenge/")
-    else {
+    let Some(token) = r.path().as_bytes().strip_prefix(b"/.well-known/acme-challenge/") else {
         return Status::NGX_DECLINED;
     };
 
@@ -157,10 +153,7 @@ http_request_handler!(handler, |r: &mut ngx::http::Request| {
         (*buf).last = (*buf).end;
     }
 
-    let mut chain = ngx_chain_t {
-        buf,
-        next: ptr::null_mut(),
-    };
+    let mut chain = ngx_chain_t { buf, next: ptr::null_mut() };
 
     let r: *mut ngx_http_request_t = r.into();
     unsafe { ngx_http_finalize_request(r, ngx_http_output_filter(r, &mut chain)) }

--- a/src/acme/solvers/tls_alpn.rs
+++ b/src/acme/solvers/tls_alpn.rs
@@ -43,12 +43,11 @@ use openssl_foreign_types::ForeignType;
 use openssl_sys::{SSL_get_ex_data, SSL, SSL_CTX, SSL_TLSEXT_ERR_ALERT_FATAL, SSL_TLSEXT_ERR_OK};
 use zeroize::{Zeroize, Zeroizing};
 
+use super::{ChallengeSolver, SolverError};
 use crate::acme;
 use crate::acme::resource::{Challenge, ChallengeKind};
 use crate::conf::identifier::Identifier;
 use crate::conf::AcmeMainConfig;
-
-use super::{ChallengeSolver, SolverError};
 
 const SHA256_DIGEST_LENGTH: usize = 0x20;
 
@@ -86,8 +85,8 @@ pub fn postconfiguration(_cf: &mut ngx_conf_t, amcf: &mut AcmeMainConfig) -> Res
 
     unsafe {
         /*
-         * Server name callback has to be set, because otherwise `ngx_http_ssl_servername` from the
-         * initial SSL_CTX will be invoked.
+         * Server name callback has to be set, because otherwise `ngx_http_ssl_servername` from
+         * the initial SSL_CTX will be invoked.
          */
         SSL_CTX_set_tlsext_servername_callback(ssl_ctx, Some(acme_ssl_servername_cb));
         SSL_CTX_set_cert_cb(ssl_ctx, Some(acme_ssl_cert_cb), amcfp);
@@ -148,10 +147,7 @@ impl ChallengeSolver for TlsAlpn01Solver<'_> {
         let _ = key_authorization.append_within_capacity(ctx.thumbprint);
         let pkey = Zeroizing::new(ctx.pkey.private_key_to_pem_pkcs8()?);
         let pkey = NgxString::try_from_bytes_in(pkey, alloc.clone())?;
-        let resp = TlsAlpn01Response {
-            key_authorization,
-            pkey,
-        };
+        let resp = TlsAlpn01Response { key_authorization, pkey };
         let servername = NgxString::try_from_bytes_in(identifier.value(), alloc)?;
         self.0.write().try_insert(servername, resp)?;
         Ok(())
@@ -226,11 +222,7 @@ impl SslClientHello {
                 SSL_CLIENT_HELLO_ERROR
             }
             Err(err) => {
-                ngx_log_error!(
-                    NGX_LOG_WARN,
-                    this.connection().log,
-                    "acme/tls-alpn-01: {err}"
-                );
+                ngx_log_error!(NGX_LOG_WARN, this.connection().log, "acme/tls-alpn-01: {err}");
                 SSL_CLIENT_HELLO_ERROR
             }
         }
@@ -280,11 +272,7 @@ impl SslClientHello {
             },
             Ok(_) => openssl_sys::ssl_select_cert_result_t_ssl_select_cert_success,
             Err(err) => {
-                ngx_log_error!(
-                    NGX_LOG_WARN,
-                    this.connection().log,
-                    "acme/tls-alpn-01: {err}"
-                );
+                ngx_log_error!(NGX_LOG_WARN, this.connection().log, "acme/tls-alpn-01: {err}");
                 openssl_sys::ssl_select_cert_result_t_ssl_select_cert_error
             }
         }
@@ -441,7 +429,7 @@ unsafe extern "C" fn acme_ssl_cert_cb(ssl: *mut SSL, arg: *mut c_void) -> c_int 
             PKey::private_key_from_pem(resp.pkey.as_ref()),
         )
     } else {
-        ngx_log_debug!(c.log, "acme/tls-alpn-01: no challenge registered for {id}",);
+        ngx_log_debug!(c.log, "acme/tls-alpn-01: no challenge registered for {id}");
         return 0;
     };
 
@@ -628,11 +616,7 @@ pub fn make_challenge_cert(
 
     cert_builder.append_extension(x509_ext::BasicConstraints::new().critical().ca().build()?)?;
     cert_builder.append_extension(
-        x509_ext::KeyUsage::new()
-            .critical()
-            .digital_signature()
-            .key_cert_sign()
-            .build()?,
+        x509_ext::KeyUsage::new().critical().digital_signature().key_cert_sign().build()?,
     )?;
     let subject_key_identifier =
         x509_ext::SubjectKeyIdentifier::new().build(&cert_builder.x509v3_context(None, None))?;
@@ -714,10 +698,7 @@ mod tests {
 
         for (sni, expected) in pairs {
             let mut buf: Vec<u8> = Vec::from(sni.as_bytes());
-            let mut name = ngx_str_t {
-                data: buf.as_mut_ptr(),
-                len: buf.len(),
-            };
+            let mut name = ngx_str_t { data: buf.as_mut_ptr(), len: buf.len() };
 
             let rc = acme_parse_ssl_server_name(&mut name);
             assert_eq!(&rc, expected);

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -289,12 +289,9 @@ extern "C" fn cmd_set_shared_zone(
     }
 
     if !amcf.shm_zone.is_configured() {
-        ngx_conf_log_error!(
-            NGX_LOG_EMERG,
-            cf,
-            "\"{}\" must have \"zone\" parameter",
-            unsafe { (*cmd).name }
-        );
+        ngx_conf_log_error!(NGX_LOG_EMERG, cf, "\"{}\" must have \"zone\" parameter", unsafe {
+            (*cmd).name
+        });
         return NGX_CONF_ERROR;
     }
 
@@ -307,11 +304,7 @@ extern "C" fn cmd_add_certificate(
     conf: *mut c_void,
 ) -> *mut c_char {
     let cf = unsafe { cf.as_mut().unwrap() };
-    let ascf = unsafe {
-        conf.cast::<AcmeServerConfig>()
-            .as_mut()
-            .expect("server config")
-    };
+    let ascf = unsafe { conf.cast::<AcmeServerConfig>().as_mut().expect("server config") };
 
     if ascf.order.is_some() {
         return NGX_CONF_DUPLICATE;
@@ -512,10 +505,7 @@ extern "C" fn cmd_issuer_set_external_account_key(
     crate::util::ngx_str_trim(&mut encoded);
 
     let len = encoded.len.div_ceil(4) * 3;
-    let mut key = ngx_str_t {
-        data: pool.alloc_unaligned(len).cast(),
-        len,
-    };
+    let mut key = ngx_str_t { data: pool.alloc_unaligned(len).cast(), len };
 
     if key.data.is_null() {
         return NGX_CONF_ERROR;
@@ -641,10 +631,7 @@ extern "C" fn cmd_issuer_set_state_path(
     // We need to add our prefix before we pass the path to ngx_conf_set_path_slot,
     // because otherwise it will be resolved with cycle->prefix.
     if let Some(p) = issuer::NGX_ACME_STATE_PREFIX {
-        let mut p = ngx_str_t {
-            data: p.as_ptr().cast_mut(),
-            len: p.len(),
-        };
+        let mut p = ngx_str_t { data: p.as_ptr().cast_mut(), len: p.len() };
 
         // ngx_get_full_name does not modify input buffers.
         if !Status(unsafe { nginx_sys::ngx_get_full_name(cf.pool, &mut p, &mut path) }).is_ok() {
@@ -743,12 +730,7 @@ impl AcmeMainConfig {
             if let Some(issuer) = self.issuer_mut(&ascf.issuer) {
                 issuer.add_certificate_order(cf, order)?;
             } else {
-                ngx_log_error!(
-                    NGX_LOG_EMERG,
-                    cf.log,
-                    "issuer \"{}\" is missing",
-                    ascf.issuer
-                );
+                ngx_log_error!(NGX_LOG_EMERG, cf.log, "issuer \"{}\" is missing", ascf.issuer);
                 return Err(Status::NGX_ERROR);
             };
         }

--- a/src/conf/ext.rs
+++ b/src/conf/ext.rs
@@ -26,12 +26,7 @@ impl NgxConfExt for ngx_conf_t {
 
     fn args_mut(&mut self) -> &mut [ngx_str_t] {
         // SAFETY: we know that cf.args is an array of ngx_str_t
-        unsafe {
-            self.args
-                .as_mut()
-                .map(|x| x.as_slice_mut())
-                .unwrap_or_default()
-        }
+        unsafe { self.args.as_mut().map(|x| x.as_slice_mut()).unwrap_or_default() }
     }
 
     fn error(&self, dir: impl AsRef<[u8]>, err: &dyn StdError) -> *mut c_char {

--- a/src/conf/identifier.rs
+++ b/src/conf/identifier.rs
@@ -32,10 +32,9 @@ impl<S> Identifier<S> {
         match self {
             Identifier::Dns(x) => Identifier::Dns(x.as_ref()),
             Identifier::Ip(x) => Identifier::Ip(x.as_ref()),
-            Identifier::Other { kind, value } => Identifier::Other {
-                kind: kind.as_ref(),
-                value: value.as_ref(),
-            },
+            Identifier::Other { kind, value } => {
+                Identifier::Other { kind: kind.as_ref(), value: value.as_ref() }
+            }
         }
     }
 
@@ -71,14 +70,8 @@ where
             (Identifier::Dns(x), Identifier::Dns(y)) => x == y,
             (Identifier::Ip(x), Identifier::Ip(y)) => x == y,
             (
-                Identifier::Other {
-                    kind: xk,
-                    value: xv,
-                },
-                Identifier::Other {
-                    kind: yk,
-                    value: yv,
-                },
+                Identifier::Other { kind: xk, value: xv },
+                Identifier::Other { kind: yk, value: yv },
             ) => xk == yk && xv == yv,
             _ => false,
         }
@@ -98,10 +91,9 @@ where
         match self {
             Identifier::Dns(x) => try_clone(x).map(Identifier::Dns),
             Identifier::Ip(x) => try_clone(x).map(Identifier::Ip),
-            Identifier::Other { kind, value } => Ok(Identifier::Other {
-                kind: try_clone(kind)?,
-                value: try_clone(value)?,
-            }),
+            Identifier::Other { kind, value } => {
+                Ok(Identifier::Other { kind: try_clone(kind)?, value: try_clone(value)? })
+            }
         }
     }
 }
@@ -122,12 +114,6 @@ mod tests {
 
         let id: Identifier<&str> =
             serde_json::from_str(r#"{ "type": "email", "value": "admin@example.test" }"#).unwrap();
-        assert_eq!(
-            id,
-            Identifier::Other {
-                kind: "email",
-                value: "admin@example.test"
-            }
-        );
+        assert_eq!(id, Identifier::Other { kind: "email", value: "admin@example.test" });
     }
 }

--- a/src/conf/issuer.rs
+++ b/src/conf/issuer.rs
@@ -133,8 +133,7 @@ impl Issuer {
 
     /// Checks if the issuer can be used.
     pub fn is_valid(&self) -> bool {
-        self.data
-            .is_some_and(|x| x.read().state != IssuerState::Invalid)
+        self.data.is_some_and(|x| x.read().state != IssuerState::Invalid)
     }
 
     /// Marks the last issuer login attempt as failed.
@@ -193,10 +192,7 @@ impl Issuer {
             self.ssl_verify = 1;
         }
 
-        if self
-            .ssl
-            .set_verify(cf, self.ssl_verify != 0, &mut self.ssl_trusted_certificate)
-            .is_err()
+        if self.ssl.set_verify(cf, self.ssl_verify != 0, &mut self.ssl_trusted_certificate).is_err()
         {
             return Err(IssuerError::SslVerify);
         }
@@ -215,8 +211,7 @@ impl Issuer {
             }
 
             if matches!(
-                self.resolver
-                    .map(|r| unsafe { r.as_ref() }.connections.nelts),
+                self.resolver.map(|r| unsafe { r.as_ref() }.connections.nelts),
                 Some(0) | None
             ) {
                 return Err(IssuerError::Resolver);
@@ -383,8 +378,7 @@ fn default_state_path(cf: &mut ngx_conf_t, name: &ngx_str_t) -> Result<ngx_str_t
     let reserve = "acme_".len() + name.len + 1;
 
     if let Some(p) = NGX_ACME_STATE_PREFIX {
-        path.try_reserve_exact(p.len() + reserve)
-            .map_err(|_| AllocError)?;
+        path.try_reserve_exact(p.len() + reserve).map_err(|_| AllocError)?;
         path.extend(p.as_bytes());
     }
 
@@ -460,15 +454,12 @@ impl StateDir {
 
         let stack = super::ssl::conf_read_certificate(cf, &cert)?;
         #[allow(clippy::get_first)] // ^ can return Stack or Vec, depending on the NGINX version
-        let cert = stack
-            .get(0)
-            .ok_or(super::ssl::CertificateFetchError::Fetch(c"no certificates"))?;
+        let cert =
+            stack.get(0).ok_or(super::ssl::CertificateFetchError::Fetch(c"no certificates"))?;
         let pkey = super::ssl::conf_read_private_key(cf, &key)?;
 
         if unsafe { openssl_sys::X509_check_private_key(cert.as_ptr(), pkey.as_ptr()) } != 1 {
-            return Err(CachedCertificateError::Mismatch(
-                openssl::error::ErrorStack::get(),
-            ));
+            return Err(CachedCertificateError::Mismatch(openssl::error::ErrorStack::get()));
         }
 
         let valid = Interval::from_x509(cert).unwrap_or_default();

--- a/src/conf/order.rs
+++ b/src/conf/order.rs
@@ -36,10 +36,7 @@ where
     where
         S: Default,
     {
-        Self {
-            identifiers: Vec::new_in(alloc),
-            key: Default::default(),
-        }
+        Self { identifiers: Vec::new_in(alloc), key: Default::default() }
     }
 
     /// Generates a stable unique identifier for this order.
@@ -52,13 +49,9 @@ where
 
     /// Attempts to find the first DNS identifier, with fallback to a first identifier of any kind.
     pub fn first_name(&self) -> Option<&S> {
-        let dns = self
-            .identifiers
-            .iter()
-            .find(|x| matches!(x, Identifier::Dns(_)));
+        let dns = self.identifiers.iter().find(|x| matches!(x, Identifier::Dns(_)));
 
-        dns.or_else(|| self.identifiers.first())
-            .map(Identifier::value)
+        dns.or_else(|| self.identifiers.first()).map(Identifier::value)
     }
 }
 
@@ -120,9 +113,7 @@ where
         let key = self.key.clone();
 
         let mut identifiers: Vec<Identifier<NgxString<A>>, A> = Vec::new_in(alloc.clone());
-        identifiers
-            .try_reserve_exact(self.identifiers.len())
-            .map_err(|_| AllocError)?;
+        identifiers.try_reserve_exact(self.identifiers.len()).map_err(|_| AllocError)?;
 
         for id in &self.identifiers[..] {
             identifiers.push(id.try_clone_in(alloc.clone())?);
@@ -201,8 +192,7 @@ impl CertificateOrder<&'static str, Pool> {
 
         if let Some(host) = value.strip_prefix(".") {
             let mut www = Vec::new_in(self.identifiers.allocator().clone());
-            www.try_reserve_exact(host.len() + 4)
-                .map_err(|_| AllocError)?;
+            www.try_reserve_exact(host.len() + 4).map_err(|_| AllocError)?;
             www.extend_from_slice(b"www.");
             www.extend_from_slice(host.as_bytes());
             www.make_ascii_lowercase();

--- a/src/conf/shared_zone.rs
+++ b/src/conf/shared_zone.rs
@@ -59,9 +59,7 @@ impl SharedZone {
             .position(|x| *x == b':')
             .ok_or(SharedZoneError::InvalidSize(value))?;
 
-        let (name, mut size) = value
-            .split_at(pos)
-            .ok_or(SharedZoneError::InvalidSize(value))?;
+        let (name, mut size) = value.split_at(pos).ok_or(SharedZoneError::InvalidSize(value))?;
 
         size.len -= 1; // ':'
         size.data = unsafe { size.data.add(1) };
@@ -95,9 +93,7 @@ impl SharedZone {
                     cf,
                     name,
                     *size,
-                    ptr::from_ref(crate::HttpAcmeModule::module())
-                        .cast_mut()
-                        .cast(),
+                    ptr::from_ref(crate::HttpAcmeModule::module()).cast_mut().cast(),
                 )
             })
             .ok_or(Status::NGX_ERROR)?;

--- a/src/conf/ssl.rs
+++ b/src/conf/ssl.rs
@@ -91,11 +91,7 @@ fn conf_ssl_cache_fetch<T: openssl_foreign_types::ForeignType>(
         return Ok(unsafe { T::from_ptr(p.cast()) });
     }
 
-    let err = if err.is_null() {
-        c"unknown error"
-    } else {
-        unsafe { CStr::from_ptr(err) }
-    };
+    let err = if err.is_null() { c"unknown error" } else { unsafe { CStr::from_ptr(err) } };
 
     let sslerr = openssl::error::ErrorStack::get();
     if sslerr.errors().is_empty() {
@@ -157,9 +153,7 @@ impl NgxSsl {
                     NGX_LOG_EMERG as _,
                     cf.log,
                     0,
-                    c"SSL_CTX_set_default_verify_paths() failed"
-                        .as_ptr()
-                        .cast_mut(),
+                    c"SSL_CTX_set_default_verify_paths() failed".as_ptr().cast_mut(),
                 );
 
                 return Err(Status::NGX_ERROR);

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -97,12 +97,7 @@ pub fn sign_jws<Jwk: JsonWebKey>(
         None => JwsHeaderKey::Jwk { jwk },
     };
 
-    let header = JwsHeader {
-        alg: jwk.alg(),
-        nonce,
-        url,
-        key,
-    };
+    let header = JwsHeader { alg: jwk.alg(), nonce, url, key };
 
     let header_json = serde_json::to_vec(&header)?;
 
@@ -111,11 +106,7 @@ pub fn sign_jws<Jwk: JsonWebKey>(
     let signature = jwk.compute_mac(protected.as_bytes(), payload.as_bytes())?;
     let signature = base64url(signature);
 
-    Ok(SignedMessage {
-        protected,
-        payload,
-        signature,
-    })
+    Ok(SignedMessage { protected, payload, signature })
 }
 
 impl fmt::Display for SignedMessage {

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -36,13 +36,8 @@ const NGINX_VER: &str = match nginx_sys::NGINX_VER.to_str() {
     _ => unreachable!(),
 };
 
-const NGX_ACME_USER_AGENT: &str = constcat::concat!(
-    env!("CARGO_PKG_NAME"),
-    "/",
-    env!("CARGO_PKG_VERSION"),
-    " ",
-    NGINX_VER,
-);
+const NGX_ACME_USER_AGENT: &str =
+    constcat::concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"), " ", NGINX_VER);
 
 #[allow(async_fn_in_trait)]
 pub trait HttpClient {
@@ -136,9 +131,7 @@ impl HttpClient for NgxHttpClient<'_> {
 
         let uri = core::mem::replace(req.uri_mut(), path_and_query.into());
 
-        let authority = uri
-            .authority()
-            .ok_or(HttpClientError::Uri("missing authority"))?;
+        let authority = uri.authority().ok_or(HttpClientError::Uri("missing authority"))?;
 
         {
             let headers = req.headers_mut();
@@ -151,10 +144,7 @@ impl HttpClient for NgxHttpClient<'_> {
                 http::header::USER_AGENT,
                 http::HeaderValue::from_static(NGX_ACME_USER_AGENT),
             );
-            headers.insert(
-                http::header::CONNECTION,
-                http::HeaderValue::from_static("close"),
-            );
+            headers.insert(http::header::CONNECTION, http::HeaderValue::from_static("close"));
         }
 
         let mut peer = self.connect(&uri).await?;
@@ -252,11 +242,8 @@ impl NgxHttpClient<'_> {
                 None
             };
 
-            future::poll_fn(|cx| {
-                peer.as_mut()
-                    .poll_ssl_handshake(self.ssl.as_ref(), ssl_name, cx)
-            })
-            .await?;
+            future::poll_fn(|cx| peer.as_mut().poll_ssl_handshake(self.ssl.as_ref(), ssl_name, cx))
+                .await?;
         }
 
         Ok(peer)
@@ -268,13 +255,13 @@ impl NgxHttpClient<'_> {
         addrs: &[ngx_addr_t],
     ) -> Result<Pin<Box<PeerConnection>>, io::Error> {
         /*
-         * Prefer IPv6 if available, but if the connection failed or was not established in 500ms,
-         * start connecting to an IPv4 address in parallel.
+         * Prefer IPv6 if available, but if the connection failed or was not established in
+         * 500ms, start connecting to an IPv4 address in parallel.
          * Pick the first successful connection and remember which protocol succeeded.
          *
          * Ideally, we should expire the protocol preference regularly. However, we create a new
-         * client instance each time we process scheduled updates for an issuer, so we can assume it
-         * is already shortlived.
+         * client instance each time we process scheduled updates for an issuer, so we can assume
+         * it is already shortlived.
          */
 
         let mode = self

--- a/src/net/peer_conn.rs
+++ b/src/net/peer_conn.rs
@@ -40,7 +40,8 @@ impl fmt::Display for SslVerifyError {
             // to an internal static buffer. It's safe to access it from a single-threaded nginx
             // module and that should never happen anyways.
             let s = openssl_sys::X509_verify_cert_error_string(self.0 as _);
-            // SAFETY: all returned error messages are valid pointers to nul-terminated ASCII strings.
+            // SAFETY: all returned error messages are valid pointers to nul-terminated ASCII
+            // strings.
             CStr::from_ptr(s).to_str().unwrap_or("<unknown>")
         };
 
@@ -157,12 +158,7 @@ impl PeerConnection {
 
         (*pool).as_mut().log = new_log.as_ptr();
 
-        let mut this = Self {
-            pool,
-            pc: unsafe { mem::zeroed() },
-            rev: None,
-            wev: None,
-        };
+        let mut this = Self { pool, pc: unsafe { mem::zeroed() }, rev: None, wev: None };
 
         let pc = &mut this.pc;
         pc.get = Some(ngx_event_get_peer);
@@ -518,11 +514,7 @@ unsafe extern "C" fn ngx_peer_conn_write_handler(ev: *mut nginx_sys::ngx_event_t
 
     // Handle write events posted from the ngx_event_openssl code.
     } else if Status(nginx_sys::ngx_handle_write_event(ev, 0)) != Status::NGX_OK {
-        ngx_log_error!(
-            NGX_LOG_WARN,
-            (*c).log,
-            "acme: ngx_handle_write_event() failed"
-        );
+        ngx_log_error!(NGX_LOG_WARN, (*c).log, "acme: ngx_handle_write_event() failed");
     }
 }
 
@@ -533,19 +525,13 @@ fn copy_sockaddr(pool: &ngx::core::Pool, addr: &ngx_addr_t) -> Result<ngx_addr_t
     }
 
     unsafe {
-        addr.sockaddr
-            .cast::<u8>()
-            .copy_to_nonoverlapping(sockaddr.cast(), addr.socklen as usize)
+        addr.sockaddr.cast::<u8>().copy_to_nonoverlapping(sockaddr.cast(), addr.socklen as usize)
     };
 
     let name =
         unsafe { ngx_str_t::from_bytes(pool.as_ptr(), addr.name.as_bytes()) }.ok_or(AllocError)?;
 
-    Ok(ngx_addr_t {
-        sockaddr,
-        socklen: addr.socklen,
-        name,
-    })
+    Ok(ngx_addr_t { sockaddr, socklen: addr.socklen, name })
 }
 
 // Gets a binary representation of an IP address from a well-formed [libc::sockaddr].

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,12 +15,11 @@ use ngx::log::ngx_cycle_log;
 use ngx::sync::RwLock;
 use ngx::{ngx_log_debug, ngx_log_error};
 
+pub use self::certificate::CertificateContext;
+pub use self::issuer::IssuerContext;
 use crate::acme;
 use crate::conf::shared_zone::SharedZone;
 use crate::conf::AcmeMainConfig;
-
-pub use self::certificate::CertificateContext;
-pub use self::issuer::IssuerContext;
 
 pub mod certificate;
 pub mod issuer;
@@ -60,12 +59,7 @@ pub extern "C" fn ngx_acme_shared_zone_init(
     let shm_zone = unsafe { &mut *shm_zone };
     let log = ngx_cycle_log().as_ptr();
 
-    ngx_log_debug!(
-        log,
-        "acme: init shared zone \"{}:{}\"",
-        shm_zone.shm.name,
-        shm_zone.shm.size,
-    );
+    ngx_log_debug!(log, "acme: init shared zone \"{}:{}\"", shm_zone.shm.name, shm_zone.shm.size);
 
     let oamcf = unsafe { data.cast::<AcmeMainConfig>().as_ref() };
     let amcf = unsafe { shm_zone.data.cast::<AcmeMainConfig>().as_mut().unwrap() };
@@ -86,12 +80,7 @@ pub extern "C" fn ngx_acme_shared_zone_init(
     for issuer in &mut amcf.issuers[..] {
         // Create new shared data.
         let Ok(ctx) = IssuerContext::try_new_in(issuer, alloc.clone()) else {
-            ngx_log_error!(
-                NGX_LOG_EMERG,
-                log,
-                "cannot allocate acme issuer \"{}\"",
-                issuer.name,
-            );
+            ngx_log_error!(NGX_LOG_EMERG, log, "cannot allocate acme issuer \"{}\"", issuer.name);
             return Status::NGX_ERROR.into();
         };
 
@@ -132,12 +121,7 @@ pub extern "C" fn ngx_acme_shared_zone_init(
             // sure this detail is not missed while reading.
             issuer.data = Some(unsafe { &*ptr::from_ref(ctx) });
         } else {
-            ngx_log_error!(
-                NGX_LOG_EMERG,
-                log,
-                "cannot allocate acme issuer \"{}\"",
-                issuer.name,
-            );
+            ngx_log_error!(NGX_LOG_EMERG, log, "cannot allocate acme issuer \"{}\"", issuer.name);
             return Status::NGX_ERROR.into();
         }
     }

--- a/src/state/certificate.rs
+++ b/src/state/certificate.rs
@@ -84,23 +84,14 @@ where
         };
 
         let mut chain = Vec::new_in(alloc.clone());
-        chain
-            .try_reserve_exact(self.chain.len())
-            .map_err(|_| AllocError)?;
+        chain.try_reserve_exact(self.chain.len()).map_err(|_| AllocError)?;
         chain.extend(self.chain.iter());
 
         let mut pkey = Vec::new_in(alloc);
-        pkey.try_reserve_exact(self.pkey.len())
-            .map_err(|_| AllocError)?;
+        pkey.try_reserve_exact(self.pkey.len()).map_err(|_| AllocError)?;
         pkey.extend(self.pkey.iter());
 
-        Ok(Self::Target {
-            state,
-            chain,
-            pkey,
-            valid: self.valid.clone(),
-            next,
-        })
+        Ok(Self::Target { state, chain, pkey, valid: self.valid.clone(), next })
     }
 }
 
@@ -136,14 +127,10 @@ where
             let alloc = self.chain.allocator();
 
             let mut new_chain: Vec<u8, A> = Vec::new_in(alloc.clone());
-            new_chain
-                .try_reserve_exact(PREFIX.len() + chain.len())
-                .map_err(|_| AllocError)?;
+            new_chain.try_reserve_exact(PREFIX.len() + chain.len()).map_err(|_| AllocError)?;
 
             let mut new_pkey: Vec<u8, A> = Vec::new_in(alloc.clone());
-            new_pkey
-                .try_reserve_exact(PREFIX.len() + pkey.len())
-                .map_err(|_| AllocError)?;
+            new_pkey.try_reserve_exact(PREFIX.len() + pkey.len()).map_err(|_| AllocError)?;
 
             // Zeroize is not implemented for allocator-api2 types.
             self.chain.as_mut_slice().zeroize();
@@ -241,10 +228,7 @@ where
     }
 
     pub fn is_ready(&self) -> bool {
-        matches!(
-            self.state,
-            CertificateState::Ready | CertificateState::RenewalFailed { .. }
-        )
+        matches!(self.state, CertificateState::Ready | CertificateState::RenewalFailed { .. })
     }
 
     pub fn is_renewable(&self) -> bool {

--- a/src/state/issuer.rs
+++ b/src/state/issuer.rs
@@ -46,10 +46,7 @@ impl IssuerContext {
             *value = CertificateContext::Shared(unsafe { &*ptr::from_ref(ctx) });
         }
 
-        Ok(IssuerContext {
-            state: IssuerState::Idle,
-            certificates,
-        })
+        Ok(IssuerContext { state: IssuerState::Idle, certificates })
     }
 
     pub fn set_error(&mut self, _err: &dyn StdError) -> Timestamp {

--- a/src/util.rs
+++ b/src/util.rs
@@ -54,10 +54,7 @@ pub fn read_to_ngx_str(cf: &ngx_conf_t, path: &ngx_str_t) -> Result<ngx_str_t, i
 
     let buf = match file.metadata().map(|x| x.len() as usize) {
         Ok(len) => {
-            let mut buf = ngx_str_t {
-                data: cf.pool().alloc_unaligned(len).cast(),
-                len,
-            };
+            let mut buf = ngx_str_t { data: cf.pool().alloc_unaligned(len).cast(), len };
             if buf.data.is_null() {
                 return Err(io::ErrorKind::OutOfMemory.into());
             }
@@ -79,11 +76,7 @@ pub fn read_to_ngx_str(cf: &ngx_conf_t, path: &ngx_str_t) -> Result<ngx_str_t, i
 pub fn ngx_str_trim(val: &mut ngx_str_t) {
     let b = val.as_bytes();
     let start = b.iter().take_while(|x| x.is_ascii_whitespace()).count();
-    let end = b
-        .iter()
-        .rev()
-        .take_while(|x| x.is_ascii_whitespace())
-        .count();
+    let end = b.iter().rev().take_while(|x| x.is_ascii_whitespace()).count();
 
     val.len -= start + end;
     val.data = unsafe { val.data.add(start) };
@@ -103,10 +96,7 @@ pub unsafe fn copy_bytes_with_nul(
     p.copy_from_nonoverlapping(src.as_ptr(), src.len());
     p.add(src.len()).write(b'\0');
 
-    Ok(ngx_str_t {
-        data: p,
-        len: src.len(),
-    })
+    Ok(ngx_str_t { data: p, len: src.len() })
 }
 
 pub struct OwnedPool(Pool);

--- a/src/util/future.rs
+++ b/src/util/future.rs
@@ -16,12 +16,7 @@ where
     FR: Future<Output = Result<T, E>>,
     D: Future,
 {
-    RaceWithDelay {
-        left,
-        right,
-        delay,
-        state: State::Initial,
-    }
+    RaceWithDelay { left, right, delay, state: State::Initial }
 }
 
 pin_project_lite::pin_project! {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -49,10 +49,8 @@ extern "C" fn acme_var_certificate(
         return Status::NGX_OK.into();
     };
 
-    let Some(bytes) = cert_data
-        .read()
-        .chain()
-        .and_then(|x| unsafe { ngx_str_t::from_bytes(r.pool, x) })
+    let Some(bytes) =
+        cert_data.read().chain().and_then(|x| unsafe { ngx_str_t::from_bytes(r.pool, x) })
     else {
         return Status::NGX_ERROR.into();
     };
@@ -82,10 +80,8 @@ unsafe extern "C" fn acme_var_certificate_key(
         return Status::NGX_OK.into();
     };
 
-    let Some(bytes) = cert_data
-        .read()
-        .pkey()
-        .and_then(|x| unsafe { ngx_str_t::from_bytes(r.pool, x) })
+    let Some(bytes) =
+        cert_data.read().pkey().and_then(|x| unsafe { ngx_str_t::from_bytes(r.pool, x) })
     else {
         return Status::NGX_ERROR.into();
     };


### PR DESCRIPTION
Rustfmt by default does not use the configured line width efficiently, sometimes to the point where it hurts readability.
[rustfmt:use_small_heuristics](https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=#use_small_heuristics) controls the width of all individual constructions, with `Max` offering the most dense (but still perfectly readable) layout.