### PR TITLE
Drop async tasks with the cycle.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,13 @@ extern "C" fn ngx_http_acme_init_worker(cycle: *mut ngx_cycle_t) -> ngx_int_t {
         return Status::NGX_OK.into();
     }
 
-    ngx::async_::spawn(ngx_http_acme_main_loop(amcf)).detach();
+    let task = ngx::async_::spawn(ngx_http_acme_main_loop(amcf));
+
+    // Move task handle to the cycle pool to ensure that it is dropped with the cycle.
+    let pool = unsafe { ngx::core::Pool::from_ngx_pool(cycle.pool) };
+    if pool.allocate(task).is_null() {
+        return Status::NGX_ERROR.into();
+    }
 
     Status::NGX_OK.into()
 }


### PR DESCRIPTION
We always assume that the tasks are destroyed before the cycle. Detached acme update loop could accidentally violate that assumption.

At some point in the future, I'll refactor this to start the tasks from a `ngx_event_t` handler instead of sleeping in the task itself. For now, this patch is sufficient.