### PR TITLE
Introduce local logging macros and allow tracing server communications.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ default  = ["export-modules"]
 # outside of the NGINX buildsystem. However, cargo currently does not detect
 # this configuration automatically.
 export-modules = []
+# Enable additional debug logs.
+# This feature can log sensitive information and is not meant for production
+# use.
+trace = []
 
 [profile.release]
 codegen-units = 1

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -16,7 +16,6 @@ use iri_string::types::{UriAbsoluteString, UriReferenceStr};
 use ngx::allocator::{Allocator, Box};
 use ngx::async_::sleep;
 use ngx::collections::Vec;
-use ngx::ngx_log_debug;
 use openssl::pkey::{PKey, PKeyRef, Private};
 use openssl::x509::{self, extension as x509_ext, X509Req, X509};
 use resource::{AccountStatus, ProblemCategory};
@@ -214,7 +213,7 @@ where
 
         let mut tries = core::iter::repeat(DEFAULT_RETRY_INTERVAL).take(self.network_error_retries);
 
-        ngx_log_debug!(self.log.as_ptr(), "sending request to {url:?}");
+        debug!(self.log, "sending request to {url:?}");
         let res = loop {
             let body = crate::jws::sign_jws(
                 &self.key,
@@ -241,7 +240,7 @@ where
                     // TODO: limit retries to connection errors
                     if let Some(tm) = tries.next() {
                         sleep(tm).await;
-                        ngx_log_debug!(self.log.as_ptr(), "retrying failed request ({err})");
+                        debug!(self.log, "retrying failed request ({err})");
                         continue;
                     } else {
                         return Err(err.into());
@@ -279,7 +278,7 @@ where
             };
 
             if retriable && wait_for_retry(&res, &mut tries).await {
-                ngx_log_debug!(self.log.as_ptr(), "retrying failed request ({err})");
+                debug!(self.log, "retrying failed request ({err})");
                 continue;
             }
 
@@ -323,11 +322,7 @@ where
             Profile::Required(x) => Some(x),
             Profile::Preferred(x) if self.directory.meta.profiles.contains_key(x) => Some(x),
             Profile::Preferred(x) => {
-                ngx::ngx_log_error!(
-                    nginx_sys::NGX_LOG_NOTICE,
-                    self.log.as_ptr(),
-                    "acme profile \"{x}\" is not supported by the server"
-                );
+                notice!(self.log, "acme profile \"{x}\" is not supported by the server");
                 None
             }
             _ => None,
@@ -372,7 +367,7 @@ where
     where
         A: Allocator,
     {
-        ngx_log_debug!(self.log.as_ptr(), "new certificate request: {:?}", req.identifiers);
+        debug!(self.log, "new certificate request: {:?}", req.identifiers);
         let identifiers: Vec<Identifier<&str>> =
             req.identifiers.iter().map(|x| x.as_ref()).collect();
 
@@ -409,8 +404,8 @@ where
                     pending_authorizations.push((auth_url, authorization))
                 }
                 resource::AuthorizationStatus::Valid => {
-                    ngx_log_debug!(
-                        self.log.as_ptr(),
+                    debug!(
+                        self.log,
                         "authorization {:?}: identifier {:?} already validated",
                         auth_url,
                         authorization.identifier
@@ -578,11 +573,9 @@ where
             }
         };
 
-        ngx_log_debug!(
-            self.log.as_ptr(),
-            "authorization status for {:?}: {:?}",
-            authorization.identifier,
-            result.status
+        debug!(
+            self.log,
+            "authorization status for {:?}: {:?}", authorization.identifier, result.status
         );
 
         if result.status != AuthorizationStatus::Valid {

--- a/src/acme/solvers/tls_alpn.rs
+++ b/src/acme/solvers/tls_alpn.rs
@@ -27,13 +27,12 @@ use core::ffi::{c_int, c_uint, c_void, CStr};
 use core::net::{Ipv4Addr, Ipv6Addr};
 use core::ptr;
 
-use nginx_sys::{ngx_conf_t, ngx_connection_t, ngx_str_t, NGX_LOG_WARN};
+use nginx_sys::{ngx_conf_t, ngx_connection_t, ngx_str_t};
 use ngx::allocator::Allocator;
 use ngx::collections::RbTreeMap;
 use ngx::core::{NgxString, SlabPool, Status};
 use ngx::http::{HttpModuleMainConf, HttpModuleServerConf};
 use ngx::sync::RwLock;
-use ngx::{ngx_log_debug, ngx_log_error};
 use openssl::asn1::Asn1Time;
 use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
@@ -222,7 +221,7 @@ impl SslClientHello {
                 SSL_CLIENT_HELLO_ERROR
             }
             Err(err) => {
-                ngx_log_error!(NGX_LOG_WARN, this.connection().log, "acme/tls-alpn-01: {err}");
+                warn!(this.connection(), "acme/tls-alpn-01: {err}");
                 SSL_CLIENT_HELLO_ERROR
             }
         }
@@ -272,7 +271,7 @@ impl SslClientHello {
             },
             Ok(_) => openssl_sys::ssl_select_cert_result_t_ssl_select_cert_success,
             Err(err) => {
-                ngx_log_error!(NGX_LOG_WARN, this.connection().log, "acme/tls-alpn-01: {err}");
+                warn!(this.connection(), "acme/tls-alpn-01: {err}");
                 openssl_sys::ssl_select_cert_result_t_ssl_select_cert_error
             }
         }
@@ -409,11 +408,7 @@ unsafe extern "C" fn acme_ssl_cert_cb(ssl: *mut SSL, arg: *mut c_void) -> c_int 
     let id = match acme_parse_ssl_server_name(&mut name) {
         Ok(x) => x,
         Err(err) => {
-            ngx_log_error!(
-                NGX_LOG_WARN,
-                c.log,
-                "acme/tls-alpn-01: cannot parse identifer \"{name}\": {err}"
-            );
+            warn!(c, "acme/tls-alpn-01: cannot parse identifier \"{name}\": {err}");
             return 0;
         }
     };
@@ -429,7 +424,7 @@ unsafe extern "C" fn acme_ssl_cert_cb(ssl: *mut SSL, arg: *mut c_void) -> c_int 
             PKey::private_key_from_pem(resp.pkey.as_ref()),
         )
     } else {
-        ngx_log_debug!(c.log, "acme/tls-alpn-01: no challenge registered for {id}");
+        debug!(c, "acme/tls-alpn-01: no challenge registered for {id}");
         return 0;
     };
 
@@ -437,25 +432,17 @@ unsafe extern "C" fn acme_ssl_cert_cb(ssl: *mut SSL, arg: *mut c_void) -> c_int 
     let pkey = match pkey {
         Ok(pkey) => pkey,
         Err(err) => {
-            ngx_log_error!(
-                NGX_LOG_WARN,
-                c.log,
-                "acme/tls-alpn-01: PEM_read_bio_PrivateKey() failed: {err}"
-            );
+            warn!(c, "acme/tls-alpn-01: PEM_read_bio_PrivateKey() failed: {err}");
             return 0;
         }
     };
 
-    ngx_log_debug!(c.log, "acme/tls-alpn-01: challenge for {id}");
+    debug!(c, "acme/tls-alpn-01: challenge for {id}");
 
     let cert = match make_challenge_cert(&id, &auth, &pkey) {
         Ok(x) => x,
         Err(err) => {
-            ngx_log_error!(
-                NGX_LOG_WARN,
-                c.log,
-                "acme/tls-alpn-01: make_challenge_cert({id}) failed: {err}"
-            );
+            warn!(c, "acme/tls-alpn-01: make_challenge_cert({id}) failed: {err}");
             return 0;
         }
     };

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -15,7 +15,7 @@ use nginx_sys::{
 use ngx::collections::Vec;
 use ngx::core::{Pool, Status, NGX_CONF_ERROR, NGX_CONF_OK};
 use ngx::http::{HttpModuleMainConf, HttpModuleServerConf};
-use ngx::{ngx_conf_log_error, ngx_log_error, ngx_string};
+use ngx::{ngx_conf_log_error, ngx_string};
 
 use self::ext::NgxConfExt;
 use self::issuer::Issuer;
@@ -713,16 +713,12 @@ impl AcmeMainConfig {
                 let server_names = unsafe { cscfp.server_names.as_slice() };
 
                 if let Err(err) = order.add_server_names(cf, server_names) {
-                    ngx_log_error!(NGX_LOG_EMERG, cf.log, "\"acme_certificate\": {err}");
+                    emerg!(cf, "\"acme_certificate\": {err}");
                     return Err(Status::NGX_ERROR);
                 }
 
                 if order.identifiers.is_empty() {
-                    ngx_log_error!(
-                        NGX_LOG_EMERG,
-                        cf.log,
-                        "\"acme_certificate\": no identifiers found in \"server_name\""
-                    );
+                    emerg!(cf, "\"acme_certificate\": no identifiers found in \"server_name\"");
                     return Err(Status::NGX_ERROR);
                 }
             }
@@ -730,7 +726,7 @@ impl AcmeMainConfig {
             if let Some(issuer) = self.issuer_mut(&ascf.issuer) {
                 issuer.add_certificate_order(cf, order)?;
             } else {
-                ngx_log_error!(NGX_LOG_EMERG, cf.log, "issuer \"{}\" is missing", ascf.issuer);
+                emerg!(cf, "issuer \"{}\" is missing", ascf.issuer);
                 return Err(Status::NGX_ERROR);
             };
         }

--- a/src/conf/issuer.rs
+++ b/src/conf/issuer.rs
@@ -17,7 +17,6 @@ use ngx::allocator::{AllocError, Box};
 use ngx::collections::{RbTreeMap, Vec};
 use ngx::core::{Pool, Status};
 use ngx::http::{HttpModuleLocationConf, NgxHttpCoreModule};
-use ngx::ngx_log_debug;
 use ngx::sync::RwLock;
 use openssl::pkey::{PKey, Private};
 use thiserror::Error;
@@ -236,20 +235,15 @@ impl Issuer {
         order: &CertificateOrder<&'static str, Pool>,
     ) -> Result<(), Status> {
         if self.orders.get(order).is_none() {
-            ngx_log_debug!(
-                cf.log,
-                "acme: order \"{}\" created in issuer \"{}\"",
-                order.cache_key(),
-                self.name
-            );
+            debug!(cf, "acme: order \"{}\" created in issuer \"{}\"", order.cache_key(), self.name);
 
             let mut cert = CertificateContext::Empty;
 
             if let Some(state_dir) = unsafe { StateDir::from_ptr(self.state_path) } {
                 match state_dir.load_certificate(cf, order) {
                     Ok(x) => {
-                        ngx_log_debug!(
-                            cf.log,
+                        debug!(
+                            cf,
                             "acme: found cached certificate {}/{}, next update in {:?}",
                             self.name,
                             order.cache_key(),
@@ -259,8 +253,8 @@ impl Issuer {
                     }
                     Err(CachedCertificateError::NotFound) => (),
                     Err(err) => {
-                        ngx_log_debug!(
-                            cf.log,
+                        debug!(
+                            cf,
                             "acme: cannot load certificate {}/{} from state path: {}",
                             self.name,
                             order.cache_key(),
@@ -274,8 +268,8 @@ impl Issuer {
                 return Err(Status::NGX_ERROR);
             }
         } else {
-            ngx_log_debug!(
-                cf.log,
+            debug!(
+                cf,
                 "acme: order \"{}\" already exists in issuer \"{}\"",
                 order.cache_key(),
                 self.name

--- a/src/conf/order.rs
+++ b/src/conf/order.rs
@@ -11,7 +11,6 @@ use nginx_sys::{ngx_conf_t, ngx_http_server_name_t};
 use ngx::allocator::{AllocError, Allocator, TryCloneIn};
 use ngx::collections::Vec;
 use ngx::core::{NgxString, Pool};
-use ngx::ngx_log_error;
 use siphasher::sip::SipHasher;
 use thiserror::Error;
 
@@ -148,9 +147,8 @@ impl CertificateOrder<&'static str, Pool> {
     ) -> Result<(), IdentifierError> {
         for server_name in server_names {
             if !server_name.regex.is_null() {
-                ngx_log_error!(
-                    nginx_sys::NGX_LOG_WARN,
-                    cf.log,
+                warn!(
+                    cf,
                     "\"acme_certificate\": unsupported regular expression in server_name: {}",
                     server_name.name
                 );

--- a/src/conf/shared_zone.rs
+++ b/src/conf/shared_zone.rs
@@ -9,8 +9,7 @@ use core::ptr::{self, NonNull};
 use nginx_sys::{ngx_conf_t, ngx_int_t, ngx_shm_zone_t, ngx_str_t, NGX_ERROR};
 use ngx::core::{SlabPool, Status};
 use ngx::http::HttpModule;
-use ngx::log::ngx_cycle_log;
-use ngx::{ngx_log_debug, ngx_string};
+use ngx::ngx_string;
 use thiserror::Error;
 
 pub const ACME_ZONE_NAME: ngx_str_t = ngx_string!("ngx_acme_shared");
@@ -120,11 +119,9 @@ impl SharedZone {
             None => return Status::NGX_ERROR.into(),
         };
 
-        ngx_log_debug!(
-            ngx_cycle_log().as_ptr(),
-            "shared zone \"{}\" initialized with size {}",
-            shm_zone.shm.name,
-            shm_zone.shm.size
+        debug!(
+            ngx::log::ngx_cycle_log(),
+            "shared zone \"{}\" initialized with size {}", shm_zone.shm.name, shm_zone.shm.size
         );
 
         *zone = Self::Ready(NonNull::from(shm_zone));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,11 @@ use core::{cmp, ptr};
 
 use nginx_sys::{
     ngx_conf_t, ngx_cycle_t, ngx_http_add_variable, ngx_http_module_t, ngx_int_t, ngx_module_t,
-    ngx_uint_t, NGX_HTTP_MODULE, NGX_LOG_ERR, NGX_LOG_INFO, NGX_LOG_NOTICE, NGX_LOG_WARN,
+    ngx_uint_t, NGX_HTTP_MODULE,
 };
 use ngx::core::{Status, NGX_CONF_ERROR, NGX_CONF_OK};
 use ngx::http::{HttpModule, HttpModuleMainConf, HttpModuleServerConf, Merge};
 use ngx::log::ngx_cycle_log;
-use ngx::{ngx_log_debug, ngx_log_error};
 use time::Interval;
 use zeroize::Zeroizing;
 
@@ -28,6 +27,9 @@ use crate::net::http::NgxHttpClient;
 use crate::time::Timestamp;
 use crate::util::{ngx_process, NgxProcess};
 use crate::variables::NGX_HTTP_ACME_VARS;
+
+#[macro_use]
+mod log;
 
 mod acme;
 mod conf;
@@ -163,12 +165,12 @@ extern "C" fn ngx_http_acme_init_worker(cycle: *mut ngx_cycle_t) -> ngx_int_t {
     };
 
     if !amcf.is_configured() {
-        ngx_log_debug!(cycle.log, "acme: not configured");
+        debug!(cycle.log, "acme: not configured");
         return Status::NGX_OK.into();
     }
 
     if amcf.issuers.iter().all(|x| x.orders.is_empty()) {
-        ngx_log_error!(NGX_LOG_NOTICE, cycle.log, "acme: no certificates");
+        notice!(cycle.log, "acme: no certificates");
         return Status::NGX_OK.into();
     }
 
@@ -197,7 +199,7 @@ async fn ngx_http_acme_main_loop(amcf: &AcmeMainConfig) {
         let next = ngx_http_acme_update_certificates(amcf).await;
         let next = (next - Timestamp::now()).max(ACME_MIN_INTERVAL);
 
-        ngx_log_debug!(ngx_cycle_log().as_ptr(), "acme: next update in {next:?}");
+        debug!(ngx_cycle_log(), "acme: next update in {next:?}");
         ngx::async_::sleep(next).await;
     }
 }
@@ -207,7 +209,7 @@ async fn ngx_http_acme_update_certificates(amcf: &AcmeMainConfig) -> Timestamp {
     let now = Timestamp::now();
     let mut next = now + ACME_MAX_INTERVAL;
 
-    ngx_log_debug!(log.as_ptr(), "acme: updating certificates");
+    debug!(log, "acme: updating certificates");
 
     for issuer in &amcf.issuers[..] {
         if !issuer.is_valid() {
@@ -217,12 +219,7 @@ async fn ngx_http_acme_update_certificates(amcf: &AcmeMainConfig) -> Timestamp {
         let issuer_next = match ngx_http_acme_update_certificates_for_issuer(amcf, issuer).await {
             Ok(x) => x,
             Err(err) => {
-                ngx_log_error!(
-                    NGX_LOG_WARN,
-                    log.as_ptr(),
-                    "{err} while processing renewals for acme issuer \"{}\"",
-                    issuer.name
-                );
+                warn!(log, "{err} while processing renewals for acme issuer \"{}\"", issuer.name);
                 now + ACME_DEFAULT_INTERVAL
             }
         };
@@ -259,6 +256,7 @@ async fn ngx_http_acme_update_certificates_for_issuer(
         _ => unreachable!("invalid configuration"),
     };
 
+    let issuer_id = issuer.name;
     let mut next = Timestamp::MAX;
 
     for (order, cert) in issuer.orders.iter() {
@@ -276,11 +274,7 @@ async fn ngx_http_acme_update_certificates_for_issuer(
             }
 
             if !locked.is_renewable() {
-                ngx_log_debug!(
-                    log.as_ptr(),
-                    "acme: certificate \"{issuer}/{order_id}\" is not due for renewal",
-                    issuer = issuer.name,
-                );
+                debug!(log, "acme: certificate \"{issuer_id}/{order_id}\" is not due for renewal");
                 next = cmp::min(locked.next, next);
                 continue;
             }
@@ -289,49 +283,23 @@ async fn ngx_http_acme_update_certificates_for_issuer(
         if !client.is_ready() {
             match client.new_account().await {
                 Ok(acme::NewAccountOutput::Created(x)) => {
-                    ngx_log_error!(
-                        NGX_LOG_INFO,
-                        log.as_ptr(),
-                        "account \"{}\" created for acme issuer \"{}\"",
-                        x,
-                        issuer.name
-                    );
+                    info!(log, "account \"{x}\" created for acme issuer \"{issuer_id}\"");
                     let _ = issuer.write_state_file(conf::issuer::ACCOUNT_URL_FILE, x.as_bytes());
                 }
                 Ok(acme::NewAccountOutput::Found(x)) => {
-                    ngx_log_debug!(
-                        log.as_ptr(),
-                        "account \"{}\" found for acme issuer \"{}\"",
-                        x,
-                        issuer.name
-                    );
+                    debug!(log, "account \"{x}\" found for acme issuer \"{issuer_id}\"");
                 }
                 Err(err) if err.is_invalid() => {
-                    ngx_log_error!(
-                        NGX_LOG_ERR,
-                        log.as_ptr(),
-                        "{err} while creating account for acme issuer \"{}\"",
-                        issuer.name
-                    );
+                    error!(log, "{err} while creating account for acme issuer \"{issuer_id}\"");
                     issuer.set_invalid(&err);
                     return Ok(Timestamp::MAX);
                 }
                 Err(acme::error::NewAccountError::Request(err @ RequestError::RateLimited(x))) => {
-                    ngx_log_error!(
-                        NGX_LOG_WARN,
-                        log.as_ptr(),
-                        "{err} while creating account for acme issuer \"{issuer}\"",
-                        issuer = issuer.name
-                    );
+                    warn!(log, "{err} while creating account for acme issuer \"{issuer_id}\"");
                     return Ok(Timestamp::now() + x);
                 }
                 Err(err) => {
-                    ngx_log_error!(
-                        NGX_LOG_WARN,
-                        log.as_ptr(),
-                        "{err} while creating account for acme issuer \"{}\"",
-                        issuer.name
-                    );
+                    warn!(log, "{err} while creating account for acme issuer \"{issuer_id}\"");
                     return Ok(issuer.set_error(&err));
                 }
             }
@@ -348,23 +316,15 @@ async fn ngx_http_acme_update_certificates_for_issuer(
 
                 let next = match res {
                     Ok(x) => {
-                        ngx_log_error!(
-                            NGX_LOG_INFO,
-                            log.as_ptr(),
-                            "acme certificate \"{}/{}\" issued, next update in {:?}",
-                            issuer.name,
-                            order_id,
+                        info!(
+                            log,
+                            "acme certificate \"{issuer_id}/{order_id}\" issued, next update in {:?}",
                             (x - now)
                         );
                         x
                     }
                     Err(err) => {
-                        ngx_log_error!(
-                            NGX_LOG_WARN,
-                            log.as_ptr(),
-                            "{err} while updating certificate \"{issuer}/{order_id}\"",
-                            issuer = issuer.name,
-                        );
+                        warn!(log, "{err} while updating certificate \"{issuer_id}/{order_id}\"");
                         now + ACME_MIN_INTERVAL
                     }
                 };
@@ -380,21 +340,11 @@ async fn ngx_http_acme_update_certificates_for_issuer(
                 next
             }
             Err(acme::error::NewCertificateError::Request(err @ RequestError::RateLimited(x))) => {
-                ngx_log_error!(
-                    NGX_LOG_WARN,
-                    log.as_ptr(),
-                    "{err} while updating certificate \"{issuer}/{order_id}\"",
-                    issuer = issuer.name,
-                );
+                warn!(log, "{err} while updating certificate \"{issuer_id}/{order_id}\"");
                 return Ok(Timestamp::now() + x);
             }
             Err(ref err) if err.is_invalid() => {
-                ngx_log_error!(
-                    NGX_LOG_ERR,
-                    log.as_ptr(),
-                    "{err} while updating certificate \"{issuer}/{order_id}\"",
-                    issuer = issuer.name,
-                );
+                error!(log, "{err} while updating certificate \"{issuer_id}/{order_id}\"");
                 cert.write().set_invalid(&err);
 
                 // We marked the order as invalid and will stop attempting to update it until the
@@ -403,12 +353,7 @@ async fn ngx_http_acme_update_certificates_for_issuer(
                 continue;
             }
             Err(ref err) => {
-                ngx_log_error!(
-                    NGX_LOG_WARN,
-                    log.as_ptr(),
-                    "{err} while updating certificate \"{issuer}/{order_id}\"",
-                    issuer = issuer.name,
-                );
+                warn!(log, "{err} while updating certificate \"{issuer_id}/{order_id}\"");
                 cert.write().set_error(&err)
             }
         };

--- a/src/log.rs
+++ b/src/log.rs
@@ -85,3 +85,13 @@ macro_rules! debug {
         ngx::ngx_log_debug!($crate::log::as_log_ptr(&$log), $($arg)+);
     });
 }
+
+#[cfg(feature = "trace")]
+macro_rules! trace {
+    ($($arg:tt)+) => (debug!($($arg)+))
+}
+
+#[cfg(not(feature = "trace"))]
+macro_rules! trace {
+    ($($arg:tt)+) => {};
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,87 @@
+// Copyright (c) F5, Inc.
+//
+// This source code is licensed under the Apache License, Version 2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+
+use nginx_sys::ngx_log_t;
+
+pub trait AsLogPtr {
+    fn as_log_ptr(&self) -> *mut ngx_log_t;
+}
+
+impl<T: AsLogPtr> AsLogPtr for &T {
+    fn as_log_ptr(&self) -> *mut ngx_log_t {
+        T::as_log_ptr(self)
+    }
+}
+
+impl<T: AsLogPtr> AsLogPtr for &mut T {
+    fn as_log_ptr(&self) -> *mut ngx_log_t {
+        T::as_log_ptr(self)
+    }
+}
+
+impl AsLogPtr for *mut ngx_log_t {
+    fn as_log_ptr(&self) -> *mut ngx_log_t {
+        *self
+    }
+}
+
+impl AsLogPtr for core::ptr::NonNull<ngx_log_t> {
+    fn as_log_ptr(&self) -> *mut ngx_log_t {
+        self.as_ptr()
+    }
+}
+
+impl AsLogPtr for nginx_sys::ngx_conf_t {
+    fn as_log_ptr(&self) -> *mut ngx_log_t {
+        self.log
+    }
+}
+
+impl AsLogPtr for nginx_sys::ngx_connection_t {
+    fn as_log_ptr(&self) -> *mut ngx_log_t {
+        self.log
+    }
+}
+
+#[inline(always)]
+pub fn as_log_ptr(x: impl AsLogPtr) -> *mut ngx_log_t {
+    x.as_log_ptr()
+}
+
+macro_rules! emerg {
+    ( $log:expr, $($arg:tt)+ ) => ({
+        ngx::ngx_log_error!(nginx_sys::NGX_LOG_EMERG, $crate::log::as_log_ptr(&$log), $($arg)+);
+    });
+}
+
+macro_rules! error {
+    ( $log:expr, $($arg:tt)+ ) => ({
+        ngx::ngx_log_error!(nginx_sys::NGX_LOG_ERR, $crate::log::as_log_ptr(&$log), $($arg)+);
+    });
+}
+
+macro_rules! warn {
+    ( $log:expr, $($arg:tt)+ ) => ({
+        ngx::ngx_log_error!(nginx_sys::NGX_LOG_WARN, $crate::log::as_log_ptr(&$log), $($arg)+);
+    });
+}
+
+macro_rules! notice {
+    ( $log:expr, $($arg:tt)+ ) => ({
+        ngx::ngx_log_error!(nginx_sys::NGX_LOG_NOTICE, $crate::log::as_log_ptr(&$log), $($arg)+);
+    });
+}
+
+macro_rules! info {
+    ( $log:expr, $($arg:tt)+ ) => ({
+        ngx::ngx_log_error!(nginx_sys::NGX_LOG_INFO, $crate::log::as_log_ptr(&$log), $($arg)+);
+    });
+}
+
+macro_rules! debug {
+    ( $log:expr, $($arg:tt)+ ) => ({
+        ngx::ngx_log_debug!($crate::log::as_log_ptr(&$log), $($arg)+);
+    });
+}

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -16,11 +16,10 @@ use bytes::Bytes;
 use http::{Request, Response};
 use http_body::Body;
 use http_body_util::BodyExt;
-use nginx_sys::{ngx_addr_t, ngx_log_t, ngx_resolver_t, NGX_LOG_WARN};
+use nginx_sys::{ngx_addr_t, ngx_log_t, ngx_resolver_t};
 use ngx::allocator::Box;
 use ngx::async_::resolver::Resolver;
 use ngx::async_::spawn;
-use ngx::ngx_log_error;
 use thiserror::Error;
 
 use super::peer_conn::PeerConnection;
@@ -158,7 +157,7 @@ impl HttpClient for NgxHttpClient<'_> {
         let log = self.log;
         spawn(async move {
             if let Err(err) = conn.await {
-                ngx_log_error!(NGX_LOG_WARN, log.as_ptr(), "connection error: {err}");
+                warn!(log, "connection error: {err}");
             }
         })
         .detach();

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -44,7 +44,7 @@ pub trait HttpClient {
 
     async fn request<B>(&self, req: Request<B>) -> Result<Response<Bytes>, Self::Error>
     where
-        B: Body + Send + 'static,
+        B: Body + Send + core::fmt::Debug + 'static,
         <B as Body>::Data: Send,
         <B as Body>::Error: StdError + Send + Sync;
 }
@@ -114,7 +114,7 @@ impl HttpClient for NgxHttpClient<'_> {
 
     async fn request<B>(&self, mut req: Request<B>) -> Result<Response<Bytes>, Self::Error>
     where
-        B: Body + Send + 'static,
+        B: Body + Send + core::fmt::Debug + 'static,
         <B as Body>::Data: Send,
         <B as Body>::Error: StdError + Send + Sync,
     {
@@ -146,6 +146,8 @@ impl HttpClient for NgxHttpClient<'_> {
             headers.insert(http::header::CONNECTION, http::HeaderValue::from_static("close"));
         }
 
+        trace!(self.log, "acme http: {req:?}");
+
         let mut peer = self.connect(&uri).await?;
 
         if let Some(c) = peer.connection_mut() {
@@ -171,7 +173,9 @@ impl HttpClient for NgxHttpClient<'_> {
             .map_err(HttpClientError::Body)?
             .to_bytes();
 
-        Ok(Response::from_parts(parts, body))
+        let resp = Response::from_parts(parts, body);
+        trace!(self.log, "acme http: {resp:?}");
+        Ok(resp)
     }
 }
 

--- a/src/net/peer_conn.rs
+++ b/src/net/peer_conn.rs
@@ -13,11 +13,10 @@ use std::io;
 use nginx_sys::{
     ngx_addr_t, ngx_connection_t, ngx_destroy_pool, ngx_event_connect_peer, ngx_event_get_peer,
     ngx_int_t, ngx_log_t, ngx_msec_t, ngx_peer_connection_t, ngx_pool_t, ngx_ssl_shutdown,
-    ngx_ssl_t, ngx_str_t, NGX_LOG_WARN,
+    ngx_ssl_t, ngx_str_t,
 };
 use ngx::allocator::{AllocError, Box};
 use ngx::core::Status;
-use ngx::{ngx_log_debug, ngx_log_error};
 use openssl_sys::{
     SSL_get_verify_mode, SSL_get_verify_result, X509_VERIFY_PARAM_set1_host,
     X509_VERIFY_PARAM_set1_ip,
@@ -228,13 +227,13 @@ impl PeerConnection {
         match self.connect_peer() {
             Status::NGX_OK => {
                 let c = self.connection_mut().unwrap();
-                ngx_log_debug!(c.log, "connected");
+                debug!(c.log, "connected");
                 self.unset_log_action();
                 Poll::Ready(Ok(()))
             }
             Status::NGX_AGAIN => {
                 let c = self.connection_mut().unwrap();
-                ngx_log_debug!(c.log, "connect returned NGX_AGAIN");
+                debug!(c.log, "connect returned NGX_AGAIN");
 
                 c.read().handler = Some(ngx_peer_conn_read_handler);
                 c.write().handler = Some(ngx_peer_conn_write_handler);
@@ -247,7 +246,7 @@ impl PeerConnection {
                 Poll::Pending
             }
             x => {
-                ngx_log_debug!(self.pc.log, "connect returned {x:?}");
+                debug!(self.pc.log, "connect returned {x:?}");
                 Poll::Ready(Err(io::ErrorKind::ConnectionRefused.into()))
             }
         }
@@ -284,20 +283,20 @@ impl PeerConnection {
                     }
                 }
 
-                ngx_log_debug!(c.log, "ssl_handshake succeeded");
+                debug!(c.log, "ssl_handshake succeeded");
                 c.read().handler = Some(ngx_peer_conn_read_handler);
                 c.write().handler = Some(ngx_peer_conn_write_handler);
                 self.unset_log_action();
                 Poll::Ready(Ok(()))
             }
             Status::NGX_AGAIN => {
-                ngx_log_debug!(c.log, "ssl_handshake returned NGX_AGAIN");
+                debug!(c.log, "ssl_handshake returned NGX_AGAIN");
                 unsafe { (*c.ssl).handler = Some(ngx_peer_conn_ssl_handler) };
                 self.rev = Some(cx.waker().clone());
                 Poll::Pending
             }
             x => {
-                ngx_log_debug!(c.log, "ssl_handshake returned {x:?}");
+                debug!(c.log, "ssl_handshake returned {x:?}");
                 Poll::Ready(Err(io::ErrorKind::ConnectionRefused.into()))
             }
         }
@@ -369,7 +368,7 @@ impl PeerConnection {
 
         if !c.ssl.is_null() {
             let rc = Status(unsafe { ngx_ssl_shutdown(c.as_mut()) });
-            ngx_log_debug!(c.log, "ssl shutdown returned {rc:?}");
+            debug!(c.log, "ssl shutdown returned {rc:?}");
             if rc == Status::NGX_AGAIN {
                 unsafe { (*c.ssl).handler = Some(ngx_peer_conn_ssl_shutdown_handler) };
                 self.rev = Some(cx.waker().clone());
@@ -402,7 +401,7 @@ impl PeerConnection {
         };
 
         if !c.ssl.is_null() {
-            ngx_log_debug!(c.log, "SSL connection was not shut down");
+            debug!(c.log, "SSL connection was not shut down");
             unsafe {
                 (*c.ssl).set_no_wait_shutdown(1);
                 let _ = ngx_ssl_shutdown(c.as_mut());
@@ -514,7 +513,7 @@ unsafe extern "C" fn ngx_peer_conn_write_handler(ev: *mut nginx_sys::ngx_event_t
 
     // Handle write events posted from the ngx_event_openssl code.
     } else if Status(nginx_sys::ngx_handle_write_event(ev, 0)) != Status::NGX_OK {
-        ngx_log_error!(NGX_LOG_WARN, (*c).log, "acme: ngx_handle_write_event() failed");
+        warn!((&*c), "acme: ngx_handle_write_event() failed");
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -7,13 +7,12 @@
 use core::ffi::c_void;
 use core::ptr;
 
-use nginx_sys::{ngx_int_t, ngx_shm_zone_t, NGX_LOG_EMERG};
+use nginx_sys::{ngx_int_t, ngx_shm_zone_t};
 use ngx::allocator::{AllocError, Allocator, Box, TryCloneIn};
 use ngx::collections::Queue;
 use ngx::core::{SlabPool, Status};
 use ngx::log::ngx_cycle_log;
 use ngx::sync::RwLock;
-use ngx::{ngx_log_debug, ngx_log_error};
 
 pub use self::certificate::CertificateContext;
 pub use self::issuer::IssuerContext;
@@ -59,7 +58,7 @@ pub extern "C" fn ngx_acme_shared_zone_init(
     let shm_zone = unsafe { &mut *shm_zone };
     let log = ngx_cycle_log().as_ptr();
 
-    ngx_log_debug!(log, "acme: init shared zone \"{}:{}\"", shm_zone.shm.name, shm_zone.shm.size);
+    debug!(log, "acme: init shared zone \"{}:{}\"", shm_zone.shm.name, shm_zone.shm.size);
 
     let oamcf = unsafe { data.cast::<AcmeMainConfig>().as_ref() };
     let amcf = unsafe { shm_zone.data.cast::<AcmeMainConfig>().as_mut().unwrap() };
@@ -73,20 +72,20 @@ pub extern "C" fn ngx_acme_shared_zone_init(
     let Ok(mut data) =
         AcmeSharedData::try_new_in(alloc.clone()).and_then(|x| Box::try_new_in(x, alloc.clone()))
     else {
-        ngx_log_error!(NGX_LOG_EMERG, log, "cannot allocate acme shared data");
+        emerg!(log, "cannot allocate acme shared data");
         return Status::NGX_ERROR.into();
     };
 
     for issuer in &mut amcf.issuers[..] {
         // Create new shared data.
         let Ok(ctx) = IssuerContext::try_new_in(issuer, alloc.clone()) else {
-            ngx_log_error!(NGX_LOG_EMERG, log, "cannot allocate acme issuer \"{}\"", issuer.name);
+            emerg!(log, "cannot allocate acme issuer \"{}\"", issuer.name);
             return Status::NGX_ERROR.into();
         };
 
         // Copy data from the previous cycle.
         if let Some(oissuer) = oamcf.and_then(|x| x.issuer(&issuer.name)) {
-            ngx_log_debug!(log, "acme: copy old data for issuer \"{}\"", issuer.name);
+            debug!(log, "acme: copy old data for issuer \"{}\"", issuer.name);
 
             for (order, ctx) in issuer.orders.iter_mut() {
                 // Should not fail as we just allocated all the certificate contexts.
@@ -121,7 +120,7 @@ pub extern "C" fn ngx_acme_shared_zone_init(
             // sure this detail is not missed while reading.
             issuer.data = Some(unsafe { &*ptr::from_ref(ctx) });
         } else {
-            ngx_log_error!(NGX_LOG_EMERG, log, "cannot allocate acme issuer \"{}\"", issuer.name);
+            emerg!(log, "cannot allocate acme issuer \"{}\"", issuer.name);
             return Status::NGX_ERROR.into();
         }
     }


### PR DESCRIPTION
Log changes can potentially be submitted to ngx-rust, if I don't encounter any downsides or unsoundness.

I already had the tracing patch in a local branch, but keeping it applied for ARI development was a bit inconvenient. Let's make it available for everyone.