### PR TITLE
Fix unnecessary explicit conversion.

### DIFF
--- a/src/conf/issuer.rs
+++ b/src/conf/issuer.rs
@@ -461,7 +461,7 @@ impl StateDir {
 
         let mut chain: Vec<u8, Pool> = Vec::new_in(temp_alloc.clone());
         for x509 in stack.into_iter() {
-            chain.extend(x509.to_pem()?.into_iter());
+            chain.extend(x509.to_pem()?);
         }
 
         let mut cert = CertificateContextInner::new_in(cf.pool());


### PR DESCRIPTION
Found by clippy::useless_conversion on nightly:
```
error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> src/conf/issuer.rs:464:26
    |
464 |             chain.extend(x509.to_pem()?.into_iter());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
```