### PR TITLE
Add support for ACME challengeless support using only EAB

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,15 @@ Accepted values:
 
 - `http-01` (`http`)
 - `tls-alpn-01` (`tls-alpn`)
+- `none` (`off`) — disables challenges for use with
+  challengeless ACME (e.g. with [external account binding](#external_account_key))
 
 _ACME challenges are versioned. If an unversioned name is specified,
 the module automatically selects the latest implemented version._
+
+When `none` is specified, the module expects the ACME server to
+pre-authorize all identifiers (e.g. via external account binding)
+and will skip the challenge flow entirely.
 
 ### common_name_in_csr
 
@@ -394,6 +400,29 @@ Agrees to the terms of service under which the ACME server will be used.
 Some servers require accepting the terms of service before account registration.
 The terms are usually available on the ACME server's website,
 and the URL will be printed to the error log if necessary.
+
+### csr_additional_fields
+
+**Syntax:** **`csr_additional_fields`** _`key`_=_`value`_ ...
+
+**Default:** -
+
+**Context:** acme_issuer
+
+Sets additional subject fields in the certificate signing request.
+Multiple fields can be specified in a single directive. Supported keys:
+
+- `organization` — Organization (O)
+- `organizational_unit` — Organizational Unit (OU)
+- `country` — Country (C); should be a two-letter ISO 3166-1 alpha-2 code
+- `locality` — Locality (L)
+- `state` — State or Province (ST)
+
+Example:
+
+```nginx
+csr_additional_fields "organization=My Company" country=US state=WA;
+```
 
 ### acme_shared_zone
 

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -192,7 +192,11 @@ where
     }
 
     async fn get_nonce(&self) -> Result<String, RequestError> {
-        let res = self.get(&self.directory.new_nonce).await?;
+        let req = http::Request::builder()
+            .uri(&self.directory.new_nonce)
+            .method(http::Method::HEAD)
+            .body(String::new())?;
+        let res = self.http.request(req).await.map_err(RequestError::from)?;
         try_get_header(res.headers(), &REPLAY_NONCE).ok_or(RequestError::Nonce).map(String::from)
     }
 
@@ -684,6 +688,21 @@ pub fn make_certificate_request<A: Allocator>(
         if let Some(name) = order.first_name() {
             x509_name.append_entry_by_text("CN", name)?;
         }
+    }
+    if let Some(val) = order.csr_subject.organization {
+        x509_name.append_entry_by_text("O", val)?;
+    }
+    if let Some(val) = order.csr_subject.organizational_unit {
+        x509_name.append_entry_by_text("OU", val)?;
+    }
+    if let Some(val) = order.csr_subject.country {
+        x509_name.append_entry_by_text("C", val)?;
+    }
+    if let Some(val) = order.csr_subject.locality {
+        x509_name.append_entry_by_text("L", val)?;
+    }
+    if let Some(val) = order.csr_subject.state {
+        x509_name.append_entry_by_text("ST", val)?;
     }
     let x509_name = x509_name.build();
     req.set_subject_name(&x509_name)?;

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -84,7 +84,7 @@ pub static mut NGX_HTTP_ACME_COMMANDS: [ngx_command_t; 4] = [
     ngx_command_t::empty(),
 ];
 
-static mut NGX_HTTP_ACME_ISSUER_COMMANDS: [ngx_command_t; 13] = [
+static mut NGX_HTTP_ACME_ISSUER_COMMANDS: [ngx_command_t; 14] = [
     ngx_command_t {
         name: ngx_string!("uri"),
         type_: NGX_CONF_TAKE1 as ngx_uint_t,
@@ -177,6 +177,14 @@ static mut NGX_HTTP_ACME_ISSUER_COMMANDS: [ngx_command_t; 13] = [
         name: ngx_string!("accept_terms_of_service"),
         type_: NGX_CONF_NOARGS as ngx_uint_t,
         set: Some(cmd_issuer_set_accept_tos),
+        conf: 0,
+        offset: 0,
+        post: ptr::null_mut(),
+    },
+    ngx_command_t {
+        name: ngx_string!("csr_additional_fields"),
+        type_: NGX_CONF_1MORE as ngx_uint_t,
+        set: Some(cmd_issuer_set_csr_additional_fields),
         conf: 0,
         offset: 0,
         post: ptr::null_mut(),
@@ -368,15 +376,16 @@ extern "C" fn cmd_issuer_set_challenge(
     let val = cf.args()[1];
 
     let val = match val.as_bytes() {
-        b"http" | b"http-01" => ChallengeKind::Http01,
-        b"tls-alpn" | b"tls-alpn-01" => ChallengeKind::TlsAlpn01,
+        b"http" | b"http-01" => Some(ChallengeKind::Http01),
+        b"tls-alpn" | b"tls-alpn-01" => Some(ChallengeKind::TlsAlpn01),
+        b"none" => None,
         _ => {
             ngx_conf_log_error!(NGX_LOG_EMERG, cf, "unsupported challenge: {val}");
             return NGX_CONF_ERROR;
         }
     };
 
-    issuer.challenge = Some(val);
+    issuer.challenge = val;
 
     NGX_CONF_OK
 }
@@ -642,6 +651,62 @@ extern "C" fn cmd_issuer_set_state_path(
     }
 
     unsafe { nginx_sys::ngx_conf_set_path_slot(cf, cmd, ptr::from_mut(issuer).cast()) }
+}
+
+extern "C" fn cmd_issuer_set_csr_additional_fields(
+    cf: *mut ngx_conf_t,
+    _cmd: *mut ngx_command_t,
+    conf: *mut c_void,
+) -> *mut c_char {
+    let cf = unsafe { cf.as_mut().expect("cf") };
+    let issuer = unsafe { conf.cast::<Issuer>().as_mut().expect("issuer conf") };
+
+    // NGX_CONF_1MORE ensures that args contains at least 2 elements
+    let args = cf.args();
+
+    let args = unsafe { core::slice::from_raw_parts(args.as_ptr(), args.len()) };
+
+    for arg in &args[1..] {
+        let bytes = arg.as_bytes();
+        let Some(eq_pos) = bytes.iter().position(|&b| b == b'=') else {
+            ngx_conf_log_error!(NGX_LOG_EMERG, cf, "invalid \"csr_additional_fields\" parameter: {}", arg);
+            return NGX_CONF_ERROR;
+        };
+
+        let key = &bytes[..eq_pos];
+        let val = ngx_str_t {
+            data: unsafe { arg.data.add(eq_pos + 1) },
+            len: arg.len - eq_pos - 1,
+        };
+
+        if val.is_empty() {
+            return NGX_CONF_INVALID_VALUE;
+        }
+
+        let Ok(val) = (unsafe { conf_value_to_str(&val) }) else {
+            return NGX_CONF_INVALID_VALUE;
+        };
+
+        let field = match key {
+            b"organization" => &mut issuer.csr_subject.organization,
+            b"organizational_unit" => &mut issuer.csr_subject.organizational_unit,
+            b"country" => &mut issuer.csr_subject.country,
+            b"locality" => &mut issuer.csr_subject.locality,
+            b"state" => &mut issuer.csr_subject.state,
+            _ => {
+                ngx_conf_log_error!(NGX_LOG_EMERG, cf, "unknown \"csr_additional_fields\" parameter: {}", arg);
+                return NGX_CONF_ERROR;
+            }
+        };
+
+        if field.is_some() {
+            return NGX_CONF_DUPLICATE;
+        }
+
+        *field = Some(val);
+    }
+
+    NGX_CONF_OK
 }
 
 extern "C" fn cmd_issuer_set_accept_tos(

--- a/src/conf/issuer.rs
+++ b/src/conf/issuer.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 use zeroize::Zeroizing;
 
 use super::ext::NgxConfExt;
-use super::order::CertificateOrder;
+use super::order::{CertificateOrder, CsrSubject};
 use super::pkey::PrivateKey;
 use super::ssl::NgxSsl;
 use super::AcmeMainConfig;
@@ -50,6 +50,7 @@ pub struct Issuer {
     pub challenge: Option<ChallengeKind>,
     pub common_name_in_csr: ngx_flag_t,
     pub contacts: Vec<&'static str, Pool>,
+    pub csr_subject: CsrSubject,
     pub eab_key: Option<ExternalAccountKey>,
     pub profile: Profile,
     pub resolver: Option<NonNull<ngx_resolver_t>>,
@@ -115,6 +116,7 @@ impl Issuer {
             challenge: None,
             common_name_in_csr: NGX_CONF_UNSET_FLAG,
             contacts: Vec::new_in(alloc.clone()),
+            csr_subject: CsrSubject::default(),
             eab_key: None,
             profile: Profile::Unset,
             resolver: None,
@@ -232,8 +234,10 @@ impl Issuer {
     pub fn add_certificate_order(
         &mut self,
         cf: &mut ngx_conf_t,
-        order: &CertificateOrder<&'static str, Pool>,
+        order: &mut CertificateOrder<&'static str, Pool>,
     ) -> Result<(), Status> {
+        order.csr_subject = self.csr_subject.clone();
+
         if self.orders.get(order).is_none() {
             debug!(cf, "acme: order \"{}\" created in issuer \"{}\"", order.cache_key(), self.name);
 
@@ -285,7 +289,11 @@ impl Issuer {
         if let Some(state_dir) = state_dir {
             let path = state_dir.full_path(path);
 
-            state_dir.write(&path, buf).map_err(|_| Status::NGX_ERROR)?;
+            if let Err(err) = state_dir.write(&path, buf) {
+                use std::io::Write;
+                let _ = writeln!(std::io::stderr(), "DBG write_state_file path={path:?} err={err} kind={:?}", err.kind());
+                return Err(Status::NGX_ERROR);
+            }
         }
         Ok(())
     }

--- a/src/conf/order.rs
+++ b/src/conf/order.rs
@@ -18,6 +18,15 @@ use crate::conf::ext::NgxConfExt;
 use crate::conf::identifier::Identifier;
 use crate::conf::pkey::PrivateKey;
 
+#[derive(Clone, Debug, Default)]
+pub struct CsrSubject {
+    pub organization: Option<&'static str>,
+    pub organizational_unit: Option<&'static str>,
+    pub country: Option<&'static str>,
+    pub locality: Option<&'static str>,
+    pub state: Option<&'static str>,
+}
+
 #[derive(Clone, Debug)]
 pub struct CertificateOrder<S, A>
 where
@@ -25,6 +34,7 @@ where
 {
     pub identifiers: Vec<Identifier<S>, A>,
     pub key: PrivateKey,
+    pub csr_subject: CsrSubject,
 }
 
 impl<S, A> CertificateOrder<S, A>
@@ -35,7 +45,7 @@ where
     where
         S: Default,
     {
-        Self { identifiers: Vec::new_in(alloc), key: Default::default() }
+        Self { identifiers: Vec::new_in(alloc), key: Default::default(), csr_subject: Default::default() }
     }
 
     /// Generates a stable unique identifier for this order.
@@ -110,6 +120,7 @@ where
 
     fn try_clone_in<A: Allocator + Clone>(&self, alloc: A) -> Result<Self::Target<A>, AllocError> {
         let key = self.key.clone();
+        let csr_subject = self.csr_subject.clone();
 
         let mut identifiers: Vec<Identifier<NgxString<A>>, A> = Vec::new_in(alloc.clone());
         identifiers.try_reserve_exact(self.identifiers.len()).map_err(|_| AllocError)?;
@@ -118,7 +129,7 @@ where
             identifiers.push(id.try_clone_in(alloc.clone())?);
         }
 
-        Ok(Self::Target { identifiers, key })
+        Ok(Self::Target { identifiers, key, csr_subject })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,8 @@ async fn ngx_acme_update_certificates_for_issuer(
             let tls_solver = acme::solvers::tls_alpn::TlsAlpn01Solver::new(&amsh.tls_alpn_01_state);
             client.add_solver(tls_solver);
         }
-        _ => unreachable!("invalid configuration"),
+        // Challengeless ACME (e.g. with external account binding): no solver needed.
+        _ => {}
     };
 
     let mut next = Timestamp::MAX;

--- a/t/acme_conf_issuer.t
+++ b/t/acme_conf_issuer.t
@@ -24,7 +24,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http http_ssl/)->plan(8);
+my $t = Test::Nginx->new()->has(qw/http http_ssl/)->plan(14);
 
 use constant TEMPLATE_CONF => <<'EOF';
 
@@ -175,6 +175,105 @@ acme_issuer example {
 resolver 127.0.0.1:%%PORT_8980_UDP%%;
 
 EOF
+
+
+is(check($t, <<'EOF' ), undef, 'challenge none');
+
+acme_shared_zone zone=ngx_acme_shared:1M;
+
+acme_issuer example {
+    uri https://localhost:%%PORT_9000%%/dir;
+    account_key ecdsa:256;
+    challenge none;
+    ssl_verify off;
+    state_path %%TESTDIR%%;
+    accept_terms_of_service;
+}
+
+resolver 127.0.0.1:%%PORT_8980_UDP%%;
+
+EOF
+
+
+is(check($t, <<'EOF' ), undef, 'csr_additional_fields valid');
+
+acme_shared_zone zone=ngx_acme_shared:1M;
+
+acme_issuer example {
+    uri https://localhost:%%PORT_9000%%/dir;
+    account_key ecdsa:256;
+    challenge http;
+    ssl_verify off;
+    state_path %%TESTDIR%%;
+    accept_terms_of_service;
+    csr_additional_fields "organization=My Company" country=US state=WA
+                          locality=Seattle organizational_unit=Eng;
+}
+
+resolver 127.0.0.1:%%PORT_8980_UDP%%;
+
+EOF
+
+
+like(check($t, <<'EOF' ), qr/\[emerg].*unknown "csr_additional_fields" parameter/, 'csr_additional_fields unknown key');
+
+acme_issuer example {
+    uri https://localhost:%%PORT_9000%%/dir;
+    challenge http;
+    ssl_verify off;
+    state_path %%TESTDIR%%;
+    csr_additional_fields email=foo@example.test;
+}
+
+resolver 127.0.0.1:%%PORT_8980_UDP%%;
+
+EOF
+
+
+like(check($t, <<'EOF' ), qr/\[emerg].*invalid "csr_additional_fields" parameter/, 'csr_additional_fields missing equals');
+
+acme_issuer example {
+    uri https://localhost:%%PORT_9000%%/dir;
+    challenge http;
+    ssl_verify off;
+    state_path %%TESTDIR%%;
+    csr_additional_fields organization;
+}
+
+resolver 127.0.0.1:%%PORT_8980_UDP%%;
+
+EOF
+
+
+like(check($t, <<'EOF' ), qr/\[emerg].*invalid value/, 'csr_additional_fields empty value');
+
+acme_issuer example {
+    uri https://localhost:%%PORT_9000%%/dir;
+    challenge http;
+    ssl_verify off;
+    state_path %%TESTDIR%%;
+    csr_additional_fields organization=;
+}
+
+resolver 127.0.0.1:%%PORT_8980_UDP%%;
+
+EOF
+
+
+like(check($t, <<'EOF' ), qr/\[emerg].*(duplicate|is duplicate)/, 'csr_additional_fields duplicate key');
+
+acme_issuer example {
+    uri https://localhost:%%PORT_9000%%/dir;
+    challenge http;
+    ssl_verify off;
+    state_path %%TESTDIR%%;
+    csr_additional_fields organization=A organization=B;
+}
+
+resolver 127.0.0.1:%%PORT_8980_UDP%%;
+
+EOF
+
 
 # stop and clear the log to avoid triggering sanitizer checks
 


### PR DESCRIPTION
### Proposed changes

Challengeless ACME: support ACME servers that pre-authorize identifiers (e.g. via EAB) and don't require http-01 / tls-alpn-01. Support additional CSR subject fields - new csr_additional_fields directive to set O, OU, C, L, ST in the certificate signing request. Useful to support internal PKI providers like Venafi which issue certificates to services hosted in corporate networks to which issuer doesn't have access.

We're running nginx with this change in our corporate network and didn't notice any issues so far.

**Detailed description:**
1. challenge none (alias off): skips the challenge flow; no solver registered.
2. get_nonce: uses HEAD on new_nonce per [RFC 8555 §7.2.](https://datatracker.ietf.org/doc/html/rfc8555#section-7.2)
3. Order:authorizations is now optional during deserialization. Some providers like Venafi require it if ACME is done only using EAB.
5. csr_additional_fields key=value ... (new acme_issuer directive): sets organization, organizational_unit, country, locality, state on the CSR. Rejects unknown keys, missing =, empty values, and duplicates.
6. README updated
7. Added tests

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
