### PR TITLE
Order:authorizations is now optional during deserialization

### DIFF
--- a/src/acme/resource.rs
+++ b/src/acme/resource.rs
@@ -94,6 +94,7 @@ pub struct Order<'a> {
     #[serde(default)]
     pub error: Option<Problem>,
     #[serde(deserialize_with = "deserialize_vec_of_uri")]
+    #[serde(default)]
     pub authorizations: Vec<Uri>,
     #[serde(with = "http_serde::uri")]
     pub finalize: Uri,
@@ -484,6 +485,21 @@ mod tests {
             }"#,
         )
         .unwrap();
+
+        // Challengeless ACME orders (e.g. via external account binding with
+        // server-side pre-authorization) may omit the "authorizations" field.
+        let order: Order = serde_json::from_str(
+            r#"{
+                "status": "ready",
+                "identifiers": [
+                    { "type": "dns", "value": "example.org" }
+                ],
+                "finalize": "https://example.com/acme/order/TOlocE8rfgo/finalize"
+            }"#,
+        )
+        .unwrap();
+
+        assert!(order.authorizations.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
### Proposed changes

Order:authorizations is now optional during deserialization. Some providers like Venafi require it if ACME is done only using EAB. Added separately as requested in https://github.com/nginx/nginx-acme/pull/177 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
