### PR TITLE
ACME: dns-persist-01 challenge support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+Features:
+
+* Support for the draft dns-persist-01 challenge, enabled with
+  `challenge dns-persist-01`.  Validation is performed against a persistent
+  DNS record provisioned out of band, so the module needs neither DNS
+  credentials nor an externally reachable listener.  This is also the only
+  challenge type that can authorize wildcard identifiers.
+
 ## 0.4.1 (May 1, 2026)
 
 Bugfixes:

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ certificate management (ACMEv2) protocol.
 The module implements following specifications:
 
 - [RFC8555] (Automatic Certificate Management Environment) with limitations:
-    - Only HTTP-01 challenge type is supported
+    - The DNS-01 challenge type is not supported
 - [RFC8737] (ACME TLS Application-Layer Protocol Negotiation (ALPN) Challenge
   Extension)
 - [RFC8738] (ACME IP Identifier Validation Extension)
 - [RFC9773] (ACME Renewal Information (ARI) Extension)
 - [draft-ietf-acme-profiles] (ACME Profiles Extension, version 01)
+- [draft-ietf-acme-dns-persist] (ACME dns-persist-01 Challenge)
 
 [NGINX]: https://nginx.org/
 [RFC8555]: https://datatracker.ietf.org/doc/html/rfc8555
@@ -25,6 +26,7 @@ The module implements following specifications:
 [RFC8738]: https://datatracker.ietf.org/doc/html/rfc8738
 [RFC9773]: https://datatracker.ietf.org/doc/html/rfc9773
 [draft-ietf-acme-profiles]: https://datatracker.ietf.org/doc/draft-ietf-acme-profiles/
+[draft-ietf-acme-dns-persist]: https://datatracker.ietf.org/doc/draft-ietf-acme-dns-persist/
 
 ## Getting Started
 
@@ -190,6 +192,59 @@ server {
 }
 ```
 
+## Persistent DNS validation
+
+With `challenge dns-persist-01`, the ACME server does not ask the module to
+publish anything at validation time.  Instead it looks up a TXT record that
+authorizes an ACME account to request certificates for the identifier,
+provisioned once by whoever controls the DNS zone:
+
+```
+_validation-persist.example.com.  IN TXT  "acme.example.com; accounturi=<account URI>"
+```
+
+The first field is the
+[issuer domain name](https://datatracker.ietf.org/doc/html/rfc8659#section-4.1)
+of the ACME server, and `accounturi` identifies the account.  Both values are
+provided by the ACME server, and the module logs the expected record at the
+`info` level on every validation attempt:
+
+```
+acme/dns-persist-01: DNS:example.com expects a TXT record at
+"_validation-persist.example.com" with the value
+"acme.example.com; accounturi=https://acme.example.com/acct/1234"
+```
+
+The account URI is also written to `account.url` in the
+[state_path](#state_path) directory when the account is registered.
+
+This challenge type does not require the module to have any DNS credentials,
+and does not need an externally reachable listener.  It is the only supported
+way to issue a wildcard certificate:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name *.example.com;
+
+    acme_certificate example;
+
+    ssl_certificate       $acme_certificate;
+    ssl_certificate_key   $acme_certificate_key;
+    ssl_certificate_cache max=2;
+}
+```
+
+A wildcard identifier is only authorized if the record carries the `wildcard`
+policy, and the record is still looked up at the base domain:
+
+```
+_validation-persist.example.com.  IN TXT  "acme.example.com; accounturi=<account URI>; policy=wildcard"
+```
+
+The optional `persistUntil`=_`seconds`_ parameter, a UTC timestamp in seconds
+since the Epoch, limits how long the record stays valid.
+
 ## Directives
 
 > [!IMPORTANT]
@@ -255,9 +310,14 @@ Accepted values:
 
 - `http-01` (`http`)
 - `tls-alpn-01` (`tls-alpn`)
+- `dns-persist-01` (`dns-persist`) (0.5.0)
 
 _ACME challenges are versioned. If an unversioned name is specified,
 the module automatically selects the latest implemented version._
+
+The `dns-persist-01` challenge is validated against a persistent DNS record
+that has to be provisioned once, before the first certificate is requested.
+See [Persistent DNS validation](#persistent-dns-validation) below.
 
 ### common_name_in_csr
 
@@ -424,7 +484,11 @@ issuer _`issuer`_.
 The explicit list of identifiers can be omitted. In this case, the identifiers
 will be taken from the [server_name] directive in the same [server] block.
 Not all values accepted in the [server_name] are valid certificate identifiers:
-regular expressions and wildcards are not supported.
+regular expressions are not supported.
+
+A wildcard identifier, such as `*.example.com`, is accepted, but most ACME
+servers will only authorize it with the
+[dns-persist-01](#persistent-dns-validation) challenge.
 
 [server_name]: https://nginx.org/en/docs/http/ngx_http_core_module.html#server_name
 [server]: https://nginx.org/en/docs/http/ngx_http_core_module.html#server

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -67,6 +67,8 @@ pub struct NewCertificateOutput {
 }
 
 pub struct AuthorizationContext<'a> {
+    /// Log object for the challenge solvers.
+    pub log: NonNull<nginx_sys::ngx_log_t>,
     /// Account key thumbprint.
     pub thumbprint: &'a [u8],
     /// A private key generated for the new certificate request.
@@ -473,7 +475,8 @@ where
 
         let pkey = req.key.generate()?;
 
-        let order = AuthorizationContext { thumbprint: self.key.thumbprint(), pkey: &pkey };
+        let order =
+            AuthorizationContext { log: self.log, thumbprint: self.key.thumbprint(), pkey: &pkey };
 
         for (url, authorization) in pending_authorizations {
             self.do_authorization(&order, url, authorization).await?;
@@ -595,7 +598,7 @@ where
             })
             .ok_or(NewCertificateError::NoSupportedChallenges)?;
 
-        solver.register(order, &identifier, challenge)?;
+        solver.register(order, &identifier, authorization.wildcard == Some(true), challenge)?;
 
         scopeguard::defer! {
             let _ = solver.unregister(&identifier, challenge);

--- a/src/acme/resource.rs
+++ b/src/acme/resource.rs
@@ -133,6 +133,8 @@ pub enum ChallengeKind {
     Http01,
     #[serde(rename = "dns-01")]
     Dns01,
+    #[serde(rename = "dns-persist-01")]
+    DnsPersist01,
     #[serde(rename = "tls-alpn-01")]
     TlsAlpn01,
     #[serde(untagged)]
@@ -163,6 +165,12 @@ pub struct Challenge {
     pub error: Option<Problem>,
     #[serde(default)] // Some challenge types may not have a token.
     pub token: String,
+    /// URI of the ACME account authorized to request the certificate (dns-persist-01).
+    #[serde(default, rename = "accounturi", with = "http_serde::option::uri")]
+    pub account_uri: Option<Uri>,
+    /// Issuer domain names accepted in the persistent validation record (dns-persist-01).
+    #[serde(default, rename = "issuer-domain-names")]
+    pub issuer_domain_names: Vec<String>,
 }
 
 /// RFC9773 RenewalInfo Object
@@ -542,6 +550,45 @@ mod tests {
         assert_eq!(auth.challenges[0].kind, ChallengeKind::Http01);
         assert_eq!(auth.challenges[1].kind, ChallengeKind::Dns01);
         assert_eq!(auth.challenges[2].kind, ChallengeKind::TlsAlpn01);
+    }
+
+    #[test]
+    fn authorization_dns_persist() {
+        // draft-ietf-acme-dns-persist Section 3.1: the challenge object carries no token, but
+        // has "accounturi" and "issuer-domain-names" instead.
+        let auth: Authorization = serde_json::from_str(
+            r#"
+            {
+                "status": "pending",
+                "identifier": {
+                    "type": "dns",
+                    "value": "www.example.org"
+                },
+                "challenges": [
+                    {
+                        "type": "dns-persist-01",
+                        "url": "https://example.com/acme/chall/prV_B7yEyA4",
+                        "status": "pending",
+                        "accounturi": "https://example.com/acme/acct/evOfKhNU60wg",
+                        "issuer-domain-names": ["example.com", "example.net"]
+                    }
+                ],
+
+                "wildcard": true
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(auth.challenges.len(), 1);
+
+        let challenge = &auth.challenges[0];
+        assert_eq!(challenge.kind, ChallengeKind::DnsPersist01);
+        assert!(challenge.token.is_empty());
+        assert_eq!(
+            challenge.account_uri.as_ref().map(ToString::to_string).as_deref(),
+            Some("https://example.com/acme/acct/evOfKhNU60wg")
+        );
+        assert_eq!(challenge.issuer_domain_names, ["example.com", "example.net"]);
     }
 
     #[test]

--- a/src/acme/solvers.rs
+++ b/src/acme/solvers.rs
@@ -9,6 +9,7 @@ use super::resource::{Challenge, ChallengeKind};
 use super::AuthorizationContext;
 use crate::conf::identifier::Identifier;
 
+pub mod dns_persist;
 pub mod http;
 pub mod tls_alpn;
 
@@ -23,10 +24,15 @@ pub enum SolverError {
 pub trait ChallengeSolver {
     fn supports(&self, c: &ChallengeKind) -> bool;
 
+    /// Prepares the response to `challenge` for `identifier`.
+    ///
+    /// `wildcard` is set if the authorization covers the wildcard form of the identifier; note
+    /// that the identifier itself is always the base name, as specified in RFC8555 Section 7.1.4.
     fn register(
         &self,
         ctx: &AuthorizationContext,
         identifier: &Identifier<&str>,
+        wildcard: bool,
         challenge: &Challenge,
     ) -> Result<(), SolverError>;
 

--- a/src/acme/solvers/dns_persist.rs
+++ b/src/acme/solvers/dns_persist.rs
@@ -1,0 +1,83 @@
+// Copyright (c) F5, Inc.
+//
+// This source code is licensed under the Apache License, Version 2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+
+//! ACME dns-persist-01 challenge implementation.
+//!
+//! High level overview:
+//!
+//! Unlike the other challenge types, dns-persist-01 does not require the client to publish
+//! anything at validation time.  The domain owner provisions a persistent TXT record at
+//! `_validation-persist.<identifier>` once, naming the CA and the ACME account allowed to request
+//! certificates for the identifier.  The CA looks that record up on every validation attempt.
+//!
+//! That leaves nothing for the solver to set up or tear down: we only have to acknowledge that the
+//! challenge type is supported, so that it is not filtered out of the authorization object, and
+//! let the generic code POST the response to the challenge URL.
+//!
+//! The one thing we can usefully do here is to log the record the CA expects to see.  Both values
+//! needed to construct it are provided by the server in the challenge object, and an incorrect or
+//! missing record is the only way this challenge can fail.
+
+use super::{ChallengeSolver, SolverError};
+use crate::acme;
+use crate::acme::resource::{Challenge, ChallengeKind};
+use crate::conf::identifier::Identifier;
+
+/// Label of the persistent validation record.
+const VALIDATION_LABEL: &str = "_validation-persist";
+
+#[derive(Debug, Default)]
+pub struct DnsPersist01Solver;
+
+impl DnsPersist01Solver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ChallengeSolver for DnsPersist01Solver {
+    fn supports(&self, c: &ChallengeKind) -> bool {
+        matches!(c, ChallengeKind::DnsPersist01)
+    }
+
+    fn register(
+        &self,
+        ctx: &acme::AuthorizationContext,
+        identifier: &Identifier<&str>,
+        wildcard: bool,
+        challenge: &Challenge,
+    ) -> Result<(), SolverError> {
+        // The record is provisioned externally; there's nothing to publish here.
+        // Log what the server asked for, as that is the only actionable output we can produce if
+        // the validation fails.
+        let Some(account_uri) = challenge.account_uri.as_ref() else {
+            return Ok(());
+        };
+
+        // A wildcard authorization is only granted by a record with the "wildcard" policy, but it
+        // is still looked up at the base name.
+        let policy = if wildcard { "; policy=wildcard" } else { "" };
+
+        for issuer_domain_name in &challenge.issuer_domain_names {
+            info!(
+                ctx.log,
+                "acme/dns-persist-01: {identifier} expects a TXT record at \
+                 \"{VALIDATION_LABEL}.{}\" with the value \"{issuer_domain_name}; \
+                 accounturi={account_uri}{policy}\"",
+                identifier.value(),
+            );
+        }
+
+        Ok(())
+    }
+
+    fn unregister(
+        &self,
+        _identifier: &Identifier<&str>,
+        _challenge: &Challenge,
+    ) -> Result<(), SolverError> {
+        Ok(())
+    }
+}

--- a/src/acme/solvers/http.rs
+++ b/src/acme/solvers/http.rs
@@ -63,6 +63,7 @@ impl ChallengeSolver for Http01Solver<'_> {
         &self,
         ctx: &acme::AuthorizationContext,
         _identifier: &Identifier<&str>,
+        _wildcard: bool,
         challenge: &Challenge,
     ) -> Result<(), SolverError> {
         let alloc = self.0.read().allocator().clone();

--- a/src/acme/solvers/tls_alpn.rs
+++ b/src/acme/solvers/tls_alpn.rs
@@ -134,6 +134,7 @@ impl ChallengeSolver for TlsAlpn01Solver<'_> {
         &self,
         ctx: &acme::AuthorizationContext,
         identifier: &Identifier<&str>,
+        _wildcard: bool,
         challenge: &Challenge,
     ) -> Result<(), SolverError> {
         let alloc = self.0.read().allocator().clone();

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -369,6 +369,7 @@ extern "C" fn cmd_issuer_set_challenge(
 
     let val = match val.as_bytes() {
         b"http" | b"http-01" => ChallengeKind::Http01,
+        b"dns-persist" | b"dns-persist-01" => ChallengeKind::DnsPersist01,
         b"tls-alpn" | b"tls-alpn-01" => ChallengeKind::TlsAlpn01,
         _ => {
             ngx_conf_log_error!(NGX_LOG_EMERG, cf, "unsupported challenge: {val}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,9 @@ async fn ngx_acme_update_certificates_for_issuer(
             let http_solver = acme::solvers::http::Http01Solver::new(&amsh.http_01_state);
             client.add_solver(http_solver);
         }
+        Some(acme::ChallengeKind::DnsPersist01) => {
+            client.add_solver(acme::solvers::dns_persist::DnsPersist01Solver::new());
+        }
         Some(acme::ChallengeKind::TlsAlpn01) => {
             let tls_solver = acme::solvers::tls_alpn::TlsAlpn01Solver::new(&amsh.tls_alpn_01_state);
             client.add_solver(tls_solver);

--- a/t/acme_conf_issuer.t
+++ b/t/acme_conf_issuer.t
@@ -24,7 +24,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http http_ssl/)->plan(8);
+my $t = Test::Nginx->new()->has(qw/http http_ssl/)->plan(9);
 
 use constant TEMPLATE_CONF => <<'EOF';
 
@@ -156,6 +156,23 @@ acme_issuer example {
     account_key rsa:1024;
     ssl_verify off;
     state_path %%TESTDIR%%;
+}
+
+resolver 127.0.0.1:%%PORT_8980_UDP%%;
+
+EOF
+
+
+is(check($t, <<'EOF' ), undef, 'dns-persist-01 challenge');
+
+acme_shared_zone zone=ngx_acme_shared:1M;
+
+acme_issuer example {
+    uri https://localhost:%%PORT_9000%%/dir;
+    challenge dns-persist;
+    ssl_verify off;
+    state_path %%TESTDIR%%;
+    accept_terms_of_service;
 }
 
 resolver 127.0.0.1:%%PORT_8980_UDP%%;

--- a/t/acme_dns_persist.t
+++ b/t/acme_dns_persist.t
@@ -1,0 +1,177 @@
+#!/usr/bin/perl
+
+# Copyright (c) F5, Inc.
+#
+# This source code is licensed under the Apache License, Version 2.0 license
+# found in the LICENSE file in the root directory of this source tree.
+
+# Tests for ACME client: dns-persist-01 challenge.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::ACME;
+use Test::Nginx::DNS;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http http_ssl sni socket_ssl/)
+	->has_daemon('openssl');
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    resolver 127.0.0.1:%%PORT_8980_UDP%%;
+
+    acme_issuer default {
+        uri https://acme.test:%%PORT_9000%%/dir;
+        challenge dns-persist-01;
+        ssl_trusted_certificate acme.test.crt;
+        state_path %%TESTDIR%%;
+        accept_terms_of_service;
+    }
+
+    server {
+        listen       127.0.0.1:8443 ssl;
+        server_name  example.test;
+
+        acme_certificate default;
+
+        ssl_certificate $acme_certificate;
+        ssl_certificate_key $acme_certificate_key;
+    }
+
+    server {
+        listen       127.0.0.1:8443 ssl;
+        server_name  *.wildcard.test;
+
+        acme_certificate default;
+
+        ssl_certificate $acme_certificate;
+        ssl_certificate_key $acme_certificate_key;
+    }
+}
+
+EOF
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 2048
+encrypt_key = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+EOF
+
+my $d = $t->testdir();
+
+foreach my $name ('acme.test') {
+	system('openssl req -x509 -new '
+		. "-config $d/openssl.conf -subj /CN=$name/ "
+		. "-out $d/$name.crt -keyout $d/$name.key "
+		. ">>$d/openssl.out 2>&1") == 0
+		or die "Can't create certificate for $name: $!\n";
+}
+
+# The persistent validation record has to name the account registered by the
+# module, and that is only known once nginx is running.  Generate the record
+# contents at the time of the DNS query instead, from the account URL the
+# module saves to the state directory.
+
+sub persist_record {
+	my (%extra) = @_;
+
+	open my $fh, '<', "$d/account.url" or return [];
+	my $url = <$fh>;
+	close $fh;
+
+	return [] unless defined $url;
+	chomp $url;
+
+	my $policy = $extra{wildcard} ? '; policy=wildcard' : '';
+
+	return [ "pebble.letsencrypt.org; accounturi=$url$policy" ];
+}
+
+my $dp = port(8980, udp => 1);
+my @dc = (
+	{ name => 'acme.test', A => '127.0.0.1' },
+	{ name => '_validation-persist.example.test',
+		TXT => sub { persist_record() } },
+	{ name => '_validation-persist.wildcard.test',
+		TXT => sub { persist_record(wildcard => 1) } },
+	{ name => 'example.test', A => '127.0.0.1' },
+	{ name => 'wildcard.test', A => '127.0.0.1' },
+);
+
+my $acme = Test::Nginx::ACME->new($t, port(9000), port(9001),
+	$t->testdir . '/acme.test.crt',
+	$t->testdir . '/acme.test.key',
+	dns_port => $dp,
+	nosleep => 1,
+)->has(qw/dns-persist/);
+
+$t->run_daemon(\&Test::Nginx::DNS::dns_test_daemon, $t, 8980, \@dc, tcp => 1);
+$t->waitforfile($t->testdir . '/' . $dp);
+port(8980, socket => 1)->close();
+
+$t->run_daemon(\&Test::Nginx::ACME::acme_test_daemon, $t, $acme);
+$t->waitforsocket('127.0.0.1:' . $acme->port());
+
+$t->write_file('index.html', 'SUCCESS');
+$t->plan(4)->run();
+
+###############################################################################
+
+$acme->wait_certificate('example.test') or die "no certificate";
+
+like(get('example.test'), qr/SUCCESS/, 'tls request');
+
+$acme->wait_certificate('*.wildcard.test') or die "no wildcard certificate";
+
+like(get('any.wildcard.test'), qr/SUCCESS/, 'wildcard tls request');
+
+my $log = $t->read_file('error.log');
+
+my $expects = qr/expects a TXT record at "_validation-persist/;
+my $value = qr/with the value "pebble\.letsencrypt\.org; accounturi=\S+/;
+
+like($log, qr/$expects\.example\.test" $value"/, 'expected record logged');
+
+like($log, qr/$expects\.wildcard\.test" $value; policy=wildcard"/,
+	'expected wildcard record logged');
+
+###############################################################################
+
+sub get {
+	my ($host) = @_;
+
+	http_get('/',
+		SSL => 1,
+		SSL_ca_file => $acme->trusted_ca(),
+		SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_PEER(),
+		SSL_verifycn_name => $host,
+		SSL_hostname => $host,
+	);
+}
+
+###############################################################################

--- a/t/lib/Test/Nginx/ACME.pm
+++ b/t/lib/Test/Nginx/ACME.pm
@@ -30,6 +30,7 @@ our $PEBBLE = $ENV{TEST_NGINX_PEBBLE_BINARY} // 'pebble';
 
 my %features = (
 	'ari' => '2.8.0', # custom ARI responses (pebble#501)
+	'dns-persist' => '2.10.0', # dns-persist-01 challenge (pebble#536)
 	'eab' => '2.5.2', # broken in 2.5.0
 	'profile' => '2.7.0',
 	'validity' => '2.4.0',

--- a/t/lib/Test/Nginx/DNS.pm
+++ b/t/lib/Test/Nginx/DNS.pm
@@ -30,6 +30,7 @@ use constant NXDOMAIN	=> 3;
 use constant A		=> 1;
 use constant CNAME	=> 5;
 use constant PTR	=> 12;
+use constant TXT	=> 16;
 use constant AAAA	=> 28;
 use constant SRV	=> 33;
 
@@ -86,6 +87,14 @@ sub reply_handler {
 		} elsif ($type == PTR && $h->{PTR}) {
 			push @rdata, rd_name(PTR, $ttl, $h->{PTR});
 
+		} elsif ($type == TXT && $h->{TXT}) {
+			my $txt = $h->{TXT};
+			# a code reference allows to generate the record contents at
+			# the time of the query
+			$txt = $txt->() if ref $txt eq 'CODE';
+			$txt = [ $txt ] unless ref $txt eq 'ARRAY';
+			push @rdata, rd_txt($ttl, @$txt) if @$txt;
+
 		} elsif ($type == SRV && $h->{SRV}) {
 			push @rdata, rd_srv($ttl, (split ' ', $_));
 		}
@@ -130,6 +139,14 @@ sub rd_name {
 	my $rdlen = length(join '', @rdname) + @rdname + 1;
 
 	pack 'n3N n (C/a*)* x', 0xc00c, $type, IN, $ttl, $rdlen, @rdname;
+}
+
+sub rd_txt {
+	my ($ttl, @strings) = @_;
+	# TXT rdata is a sequence of length-prefixed character-strings
+	my $rdata = join '', map { pack 'C/a*', $_ } @strings;
+
+	pack 'n3N n a*', 0xc00c, TXT, IN, $ttl, length($rdata), $rdata;
 }
 
 sub rd_srv {


### PR DESCRIPTION
Fixes: https://github.com/nginx/nginx-acme/issues/169
### Proposed changes

Implements the `dns-persist-01` challenge from [draft-ietf-acme-dns-persist][draft].

Unlike dns-01, the client publishes nothing at validation time. The CA looks up a
persistent TXT record at `_validation-persist.<identifier>`, provisioned once by
whoever controls the zone, that names the CA and the authorized account. So the
module needs neither DNS provider credentials in the worker process nor an
externally reachable listener — which is what makes this one implementable here,
unlike the options discussed in #11.

It is also the only challenge type in the module that can authorize a wildcard
identifier.

```nginx
acme_issuer example {
    uri        https://acme.example.com/directory;
    challenge  dns-persist-01;
    state_path /var/cache/nginx/acme-example;
    accept_terms_of_service;
}

server {
    listen 443 ssl;
    server_name *.example.com;

    acme_certificate example;

    ssl_certificate       $acme_certificate;
    ssl_certificate_key   $acme_certificate_key;
    ssl_certificate_cache max=2;
}
```

**Detailed description:**

1. `ACME: add dns-persist-01 resource types.` The challenge object has no `token`,
   and carries `accounturi` and `issuer-domain-names` instead.

2. `ACME: dns-persist-01 challenge solver implementation.` The solver has nothing
   to publish or clean up, so most of it is logging the record the server expects
   to find, at the `info` level:

   ```
   acme/dns-persist-01: DNS:example.com expects a TXT record at
   "_validation-persist.example.com" with the value
   "acme.example.com; accounturi=https://acme.example.com/acct/1234"
   ```

   Getting that right for a wildcard order needs the scope of the authorization,
   so `ChallengeSolver::register` now also receives the wildcard flag. Happy to
   drop the logging and the extra argument if you would rather not widen the
   trait for a diagnostic.

3. `Tests: dns-persist-01 challenge tests.` Adds TXT support to the test DNS
   server. The record has to name the account registered by the module, which is
   not known until nginx is running, so the zone entry accepts a code reference
   evaluated at the time of the query.

The README note that wildcards are not accepted as identifiers has been stale
since #95; updated it, as this PR gives wildcards a use.

**Testing:** verified against Pebble 2.10.1, which implements the challenge
since 2.10.0 (letsencrypt/pebble#536): both a regular and a wildcard
certificate are issued, and the full `t/` suite passes. Not tested against
Let's Encrypt staging.

Refs #169

[draft]: https://datatracker.ietf.org/doc/draft-ietf-acme-dns-persist/

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
