### PR TITLE
Tests: fixed handling of missing IO::Socket::SSL

### DIFF
--- a/t/acme_preferred_chain.t
+++ b/t/acme_preferred_chain.t
@@ -14,9 +14,6 @@ use strict;
 
 use Test::More;
 
-use IO::Socket::SSL::Utils;
-use Net::SSLeay;
-
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
 use lib 'lib';
@@ -185,14 +182,14 @@ sub get {
 sub cert_name {
 	my ($filename) = @_;
 
-	my $cert = PEM_file2cert($filename);
+	my $cert = IO::Socket::SSL::Utils::PEM_file2cert($filename);
 
 	my $name = Net::SSLeay::X509_NAME_get_text_by_NID(
 		Net::SSLeay::X509_get_subject_name($cert),
 		Net::SSLeay::NID_commonName()
 	);
 
-	CERT_free($cert);
+	IO::Socket::SSL::Utils::CERT_free($cert);
 
 	return $name;
 }

--- a/t/lib/Test/Nginx/ACME.pm
+++ b/t/lib/Test/Nginx/ACME.pm
@@ -16,12 +16,14 @@ use base qw/ Exporter /;
 our @EXPORT_OK = qw/ acme_test_daemon /;
 
 use File::Spec;
-use IO::Socket::SSL::Utils;
 use POSIX qw/ gmtime strftime /;
 use Socket qw/ CRLF /;
 use Test::More qw//;
 
 use Test::Nginx qw//;
+
+eval { require IO::Socket::SSL::Utils; };
+Test::More::plan(skip_all => "IO::Socket::SSL not installed") if $@;
 
 eval { require JSON::PP; };
 Test::More::plan(skip_all => "JSON::PP not installed") if $@;
@@ -156,8 +158,8 @@ sub peer_certificate {
 	# Convert the result, as X509 will be destroyed with the socket.
 
 	return $format->($x509) if ref($format) eq 'CODE';
-	return CERT_asHash($x509) if $format eq 'hash';
-	return PEM_cert2string($x509);
+	return IO::Socket::SSL::Utils::CERT_asHash($x509) if $format eq 'hash';
+	return IO::Socket::SSL::Utils::PEM_cert2string($x509);
 }
 
 sub wait_certificate {


### PR DESCRIPTION
Found while setting new Illumos (OmniOS) VMs in my home lab.
It's true that most of the tests here require `IO::Socket::SSL`, but it's not appropriate to just let the test die because of a missing dependency.